### PR TITLE
breaking: add "ledger" property to transfers

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ When instantiating the plugin, your `opts.auth` needs the correct fields.
 {
   "account": "can be anything; only used for logging",
   "token": "channel name in MQTT server",
+  "prefix": "prefix for ilp address",
   "host": "host of MQTT server"
 }
 ```

--- a/src/plugin/nerd_plugin.js
+++ b/src/plugin/nerd_plugin.js
@@ -56,6 +56,11 @@ class NerdPluginVirtual extends EventEmitter {
 
     this.prefix = opts.auth.prefix
 
+    if (typeof opts.auth.prefix !== 'string') {
+      throw new TypeError('Expected opts.auth.prefix to be a string, received: ' +
+        typeof opts.auth.prefix)
+    }
+
     this.connected = false
     this.connectionConfig = opts.auth
 
@@ -118,6 +123,7 @@ class NerdPluginVirtual extends EventEmitter {
   }
 
   send (transfer) {
+    transfer.ledger = this.prefix
     return this.transferLog.get(transfer).then((storedTransfer) => {
       if (storedTransfer) {
         this.emit('_repeatTransfer', transfer)

--- a/src/plugin/noob_plugin.js
+++ b/src/plugin/noob_plugin.js
@@ -30,6 +30,12 @@ class NoobPluginVirtual extends EventEmitter {
     this.id = opts.id // not used but required for compatability with five
                       // bells connector.
     this.auth = opts.auth
+    this.prefix = opts.auth.prefix
+
+    if (typeof opts.auth.prefix !== 'string') {
+      throw new TypeError('Expected opts.auth.prefix to be a string, received: ' +
+        typeof opts.auth.prefix)
+    }
 
     this.connected = false
     this.connectionConfig = opts.auth
@@ -226,6 +232,7 @@ class NoobPluginVirtual extends EventEmitter {
   }
 
   send (outgoingTransfer) {
+    outgoingTransfer.ledger = this.prefix
     this._log('sending out a Transfer with tid: ' + outgoingTransfer.id)
     this._expectResponse(outgoingTransfer.id)
     return new Promise((resolve, reject) => {

--- a/test/conditionSpec.js
+++ b/test/conditionSpec.js
@@ -21,6 +21,7 @@ describe('Conditional transfers with Nerd and Noob', function () {
     nerd = new PluginVirtual({
       store: objStore,
       auth: {
+        prefix: 'test.nerd.',
         host: 'mqatt://test.mosquitto.org',
         token: token,
         limit: '1000',
@@ -34,6 +35,7 @@ describe('Conditional transfers with Nerd and Noob', function () {
     noob = new PluginVirtual({
       store: {},
       auth: {
+        prefix: 'test.noob.',
         host: 'mqatt://test.mosquitto.org',
         token: token,
         mockConnection: MockConnection,
@@ -63,6 +65,7 @@ describe('Conditional transfers with Nerd and Noob', function () {
       const p = new Promise((resolve) => {
         nerd.once('outgoing_prepare', (transfer, message) => {
           assert(transfer.id === 'first')
+          assert(transfer.ledger === 'test.nerd.')
           resolve()
         })
       })
@@ -75,7 +78,6 @@ describe('Conditional transfers with Nerd and Noob', function () {
       })
 
       return p
-    }).then(() => {
     }).then(() => {
       done()
     })
@@ -96,6 +98,7 @@ describe('Conditional transfers with Nerd and Noob', function () {
       const p = new Promise((resolve) => {
         noob.once('incoming_fulfill', (transfer, fulfillment) => {
           assert(transfer.id === 'first')
+          assert(transfer.ledger === 'test.nerd.')
           resolve()
         })
       })
@@ -122,6 +125,7 @@ describe('Conditional transfers with Nerd and Noob', function () {
       const p = new Promise((resolve) => {
         noob.once('outgoing_cancel', (transfer, message) => {
           assert(transfer.id === 'time_out')
+          assert(transfer.ledger === 'test.noob.')
           resolve()
         })
       })
@@ -136,7 +140,6 @@ describe('Conditional transfers with Nerd and Noob', function () {
 
       return p
     }).then(() => {
-    }).then(() => {
       done()
     })
   })
@@ -146,6 +149,7 @@ describe('Conditional transfers with Nerd and Noob', function () {
       let promise = new Promise((resolve) => {
         nerd.once('outgoing_cancel', (transfer, message) => {
           assert(transfer.id === 'time_out_3')
+          assert(transfer.ledger === 'test.nerd.')
           resolve()
         })
       })
@@ -184,6 +188,7 @@ describe('Conditional transfers with Nerd and Noob', function () {
         }, 1000)
         noob.once('outgoing_cancel', (transfer, message) => {
           assert(transfer.id === 'time_out_2')
+          assert(transfer.ledger === 'test.noob.')
           resolve()
         })
       })

--- a/test/conditionSpec.js
+++ b/test/conditionSpec.js
@@ -35,7 +35,6 @@ describe('Conditional transfers with Nerd and Noob', function () {
     noob = new PluginVirtual({
       store: {},
       auth: {
-        prefix: 'test.noob.',
         host: 'mqatt://test.mosquitto.org',
         token: token,
         mockConnection: MockConnection,
@@ -125,7 +124,7 @@ describe('Conditional transfers with Nerd and Noob', function () {
       const p = new Promise((resolve) => {
         noob.once('outgoing_cancel', (transfer, message) => {
           assert(transfer.id === 'time_out')
-          assert(transfer.ledger === 'test.noob.')
+          assert(transfer.ledger === 'test.nerd.')
           resolve()
         })
       })
@@ -188,7 +187,7 @@ describe('Conditional transfers with Nerd and Noob', function () {
         }, 1000)
         noob.once('outgoing_cancel', (transfer, message) => {
           assert(transfer.id === 'time_out_2')
-          assert(transfer.ledger === 'test.noob.')
+          assert(transfer.ledger === 'test.nerd.')
           resolve()
         })
       })

--- a/test/noobAndNerdSpec.js
+++ b/test/noobAndNerdSpec.js
@@ -21,6 +21,22 @@ describe('The Noob and the Nerd', function () {
     assert.isFunction(PluginVirtual)
   })
 
+  it('should throw if the nerd doesn\'t get a prefix', function () {
+    assert.throws(() => {
+      return new PluginVirtual({
+        store: store1,
+        auth: {
+          host: 'mqtt://test.mosquitto.org',
+          token: token,
+          limit: '1000',
+          balance: '0',
+          account: 'nerd',
+          secret: 'secret'
+        }
+      })
+    }, 'Expected opts.auth.prefix to be a string, received: undefined')
+  })
+
   it('should instantiate the nerd', () => {
     nerd = new PluginVirtual({
       store: store1,
@@ -47,7 +63,6 @@ describe('The Noob and the Nerd', function () {
     noob = new PluginVirtual({
       store: {},
       auth: {
-        prefix: 'test.noob.',
         host: 'mqtt://test.mosquitto.org',
         token: token,
         mockConnection: MockConnection,
@@ -113,7 +128,7 @@ describe('The Noob and the Nerd', function () {
       const p = new Promise((resolve) => {
         noob.once('outgoing_transfer', (transfer, message) => {
           assert(transfer.id === 'first')
-          assert(transfer.ledger === 'test.noob.')
+          assert(transfer.ledger === 'test.nerd.')
           done()
           resolve()
         })
@@ -200,7 +215,6 @@ describe('The Noob and the Nerd', function () {
       noob2 = new PluginVirtual({
         store: {},
         auth: {
-          prefix: 'test.noob2.',
           host: 'mqtt://test.mosquitto.org',
           token: token,
           mockConnection: MockConnection,
@@ -275,7 +289,7 @@ describe('The Noob and the Nerd', function () {
       return new Promise((resolve) => {
         nerd.once('reply', (transfer, message) => {
           assert(transfer.id === 'second')
-          assert(transfer.ledger === 'test.noob.')
+          assert(transfer.ledger === 'test.nerd.')
           assert(message.toString() === 'I have a message')
           resolve()
         })

--- a/test/noobAndNerdSpec.js
+++ b/test/noobAndNerdSpec.js
@@ -25,6 +25,7 @@ describe('The Noob and the Nerd', function () {
     nerd = new PluginVirtual({
       store: store1,
       auth: {
+        prefix: 'test.nerd.',
         host: 'mqtt://test.mosquitto.org',
         token: token,
         limit: '1000',
@@ -46,6 +47,7 @@ describe('The Noob and the Nerd', function () {
     noob = new PluginVirtual({
       store: {},
       auth: {
+        prefix: 'test.noob.',
         host: 'mqtt://test.mosquitto.org',
         token: token,
         mockConnection: MockConnection,
@@ -111,6 +113,7 @@ describe('The Noob and the Nerd', function () {
       const p = new Promise((resolve) => {
         noob.once('outgoing_transfer', (transfer, message) => {
           assert(transfer.id === 'first')
+          assert(transfer.ledger === 'test.noob.')
           done()
           resolve()
         })
@@ -171,6 +174,7 @@ describe('The Noob and the Nerd', function () {
       const p = new Promise((resolve) => {
         nerd.once('outgoing_transfer', (transfer, message) => {
           assert(transfer.id === 'third')
+          assert(transfer.ledger === 'test.nerd.')
           resolve()
         })
       })
@@ -196,6 +200,7 @@ describe('The Noob and the Nerd', function () {
       noob2 = new PluginVirtual({
         store: {},
         auth: {
+          prefix: 'test.noob2.',
           host: 'mqtt://test.mosquitto.org',
           token: token,
           mockConnection: MockConnection,
@@ -231,18 +236,21 @@ describe('The Noob and the Nerd', function () {
         new Promise((resolve) => {
           noob.once('incoming_transfer', (transfer, message) => {
             assert(transfer.id === 'fourth')
+            assert(transfer.ledger === 'test.nerd.')
             resolve()
           })
         }),
         new Promise((resolve) => {
           noob2.once('incoming_transfer', (transfer, message) => {
             assert(transfer.id === 'fourth')
+            assert(transfer.ledger === 'test.nerd.')
             resolve()
           })
         }),
         new Promise((resolve) => {
           nerd.once('outgoing_transfer', (transfer, message) => {
             assert(transfer.id === 'fourth')
+            assert(transfer.ledger === 'test.nerd.')
             resolve()
           })
         })
@@ -267,6 +275,7 @@ describe('The Noob and the Nerd', function () {
       return new Promise((resolve) => {
         nerd.once('reply', (transfer, message) => {
           assert(transfer.id === 'second')
+          assert(transfer.ledger === 'test.noob.')
           assert(message.toString() === 'I have a message')
           resolve()
         })
@@ -283,6 +292,7 @@ describe('The Noob and the Nerd', function () {
       return new Promise((resolve) => {
         noob.once('reply', (transfer, message) => {
           assert(transfer.id === 'fourth')
+          assert(transfer.ledger === 'test.nerd.')
           assert(message.toString() === 'I have a message too')
           resolve()
         })
@@ -395,6 +405,7 @@ describe('The Noob and the Nerd', function () {
       let tmpNerd = new PluginVirtual({
         store: store1,
         auth: {
+          prefix: 'test.tmpNerd.',
           host: 'mqatt://test.mosquitto.org',
           token: token,
           limit: '1000',


### PR DESCRIPTION
- Related to https://github.com/interledger/five-bells-connector/issues/198
- Also make the plugin constructors throw an error if `prefix` is not provided.
