### PR TITLE
fix: [BREAKING] flatten plugin options

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ npm install --save ilp-plugin-virtual
 You can test out the ledger plugin by running `npm test` on your machine.  To
 include debug information during the test, run `npm run-script verbose-test`
 
-When instantiating the plugin, your `opts.auth` needs the correct fields.
+When instantiating the plugin, your `opts` need the correct fields.
 
 ### opts.auth (Nerd)
 

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ module.exports = function (opts) {
   // if the opts.auth contains a secret then it is assumed
   // that this is the Nerd, and the NerdPluginVirtual
   // constructor is used.
-  if (opts.auth && opts.auth.secret) {
+  if (opts && opts.secret) {
     return new NerdPluginVirtual(opts)
   } else {
     return new NoobPluginVirtual(opts)

--- a/package.json
+++ b/package.json
@@ -43,11 +43,12 @@
     "validate-commit-msg": "^2.6.1"
   },
   "dependencies": {
-    "debug": "^2.2.0",
-    "mqtt": "^1.11.0",
-    "sqlite3": "^3.1.4",
     "bignumber.js": "^2.3.0",
-    "five-bells-condition": "^3.2.0"
+    "debug": "^2.2.0",
+    "five-bells-condition": "^3.2.0",
+    "mock-require": "^1.3.0",
+    "mqtt": "^1.11.0",
+    "sqlite3": "^3.1.4"
   },
   "config": {
     "ghooks": {

--- a/src/plugin/nerd_plugin.js
+++ b/src/plugin/nerd_plugin.js
@@ -64,10 +64,7 @@ class NerdPluginVirtual extends EventEmitter {
 
     this.connected = false
 
-    const MockConnection = opts.mockConnection
-    this.connection = MockConnection
-      ? (new MockConnection(opts))
-      : (new Connection(opts))
+    this.connection = new Connection(opts)
     this.connection.on('receive', (obj) => {
       this._receive(obj).catch(this._handle)
     })

--- a/src/plugin/nerd_plugin.js
+++ b/src/plugin/nerd_plugin.js
@@ -18,17 +18,18 @@ class NerdPluginVirtual extends EventEmitter {
   * Create a PluginVirtual
   * @param {object} opts contains PluginOptions for PluginVirtual.
   *
-  * @param {object} opts.store methods for persistance
-  * @param {function} opts.store.get get an element by key
-  * @param {function} opts.store.put store an element by key, value
-  * @param {function} opts.store.del delete an elemeny by key
+  * @param {object} opts._store methods for persistance
+  * @param {function} opts._store.get get an element by key
+  * @param {function} opts._store.put store an element by key, value
+  * @param {function} opts._store.del delete an elemeny by key
   *
-  * @param {object} opts.auth ledger-specific information
-  * @param {string} opts.auth.account name of your PluginVirtual (can be anything)
-  * @param {string} opts.auth.token channel to connect to in MQTT server
-  * @param {string} opts.auth.limit numeric string representing credit limit
-  * @param {string} opts.auth.balance numeric string representing starting balance
-  * @param {string} opts.auth.host hostname of MQTT server
+  * @param {string} opts.account name of your PluginVirtual (can be anything)
+  * @param {string} opts.prefix ilp address of this ledger
+  * @param {string} opts.token channel to connect to in MQTT server
+  * @param {string} opts.limit numeric string representing credit limit
+  * @param {string} opts.balance numeric string representing starting balance
+  * @param {string} opts.host hostname of MQTT server
+  * @param {object} opts.info object to be returned by getInfo
   */
   constructor (opts) {
     super()
@@ -41,41 +42,40 @@ class NerdPluginVirtual extends EventEmitter {
 
     this.id = opts.id // not used but required for compatability with five
                       // bells connector.
-    this.auth = opts.auth
-    this.store = opts.store
+    this.auth = opts
+    this.store = opts._store
     this.timers = {}
 
-    this.info = opts.auth.info || {
-      precision: opts.auth.precision || 15,
-      scale: opts.auth.scale || 15,
-      currencyCode: opts.auth.currencyCode || '???',
-      currencySymbol: opts.auth.currencySymbol || '?'
+    this.info = opts.info || {
+      precision: 15,
+      scale: 15,
+      currencyCode: '???',
+      currencySymbol: '?'
     }
 
-    this.transferLog = new TransferLog(opts.store)
+    this.transferLog = new TransferLog(opts._store)
 
-    this.prefix = opts.auth.prefix
+    this.prefix = opts.prefix
 
-    if (typeof opts.auth.prefix !== 'string') {
-      throw new TypeError('Expected opts.auth.prefix to be a string, received: ' +
-        typeof opts.auth.prefix)
+    if (typeof opts.prefix !== 'string') {
+      throw new TypeError('Expected opts.prefix to be a string, received: ' +
+        typeof opts.prefix)
     }
 
     this.connected = false
-    this.connectionConfig = opts.auth
 
-    const MockConnection = opts.auth.mockConnection
+    const MockConnection = opts.mockConnection
     this.connection = MockConnection
-      ? (new MockConnection(this.connectionConfig))
-      : (new Connection(this.connectionConfig))
+      ? (new MockConnection(opts))
+      : (new Connection(opts))
     this.connection.on('receive', (obj) => {
       this._receive(obj).catch(this._handle)
     })
 
     this.balance = new Balance({
-      store: opts.store,
-      limit: opts.auth.limit,
-      balance: opts.auth.balance
+      store: opts._store,
+      limit: opts.limit,
+      balance: opts.balance
     })
     this.balance.on('_balanceChanged', (balance) => {
       this._log('balance changed to ' + balance)

--- a/src/plugin/noob_plugin.js
+++ b/src/plugin/noob_plugin.js
@@ -29,16 +29,15 @@ class NoobPluginVirtual extends EventEmitter {
 
     this.id = opts.id // not used but required for compatability with five
                       // bells connector.
-    this.auth = opts.auth
+    this.auth = opts
     this._prefix = null
 
     this.connected = false
-    this.connectionConfig = opts.auth
 
-    const MockConnection = opts.auth.mockConnection
+    const MockConnection = opts.mockConnection
     this.connection = MockConnection
-      ? (new MockConnection(this.connectionConfig))
-      : (new Connection(this.connectionConfig))
+      ? (new MockConnection(opts))
+      : (new Connection(opts))
     this.connection.on('receive', (obj) => {
       this._receive(obj).catch(this._handle)
     })

--- a/src/plugin/noob_plugin.js
+++ b/src/plugin/noob_plugin.js
@@ -34,10 +34,7 @@ class NoobPluginVirtual extends EventEmitter {
 
     this.connected = false
 
-    const MockConnection = opts.mockConnection
-    this.connection = MockConnection
-      ? (new MockConnection(opts))
-      : (new Connection(opts))
+    this.connection = new Connection(opts)
     this.connection.on('receive', (obj) => {
       this._receive(obj).catch(this._handle)
     })

--- a/test/conditionSpec.js
+++ b/test/conditionSpec.js
@@ -1,14 +1,16 @@
 'use strict'
 
+const mockRequire = require('mock-require')
+const mock = require('./helpers/mockConnection')
+const MockConnection = mock.MockConnection
+const MockChannels = mock.MockChannels
+mockRequire('../src/model/connection', MockConnection)
+
 const PluginVirtual = require('..')
 const assert = require('chai').assert
 const newSqliteStore = require('./helpers/sqliteStore')
 const log = require('../src/util/log')('test')
 const cc = require('five-bells-condition')
-
-const mock = require('./helpers/mockConnection')
-const MockConnection = mock.MockConnection
-const MockChannels = mock.MockChannels
 
 let nerd = null
 let noob = null
@@ -17,6 +19,7 @@ let token = require('crypto').randomBytes(8).toString('hex')
 
 describe('Conditional transfers with Nerd and Noob', function () {
   it('should create the nerd and the noob', () => {
+    mockRequire('mqtt', null)
     let objStore = newSqliteStore()
     nerd = new PluginVirtual({
       _store: objStore,

--- a/test/conditionSpec.js
+++ b/test/conditionSpec.js
@@ -19,28 +19,24 @@ describe('Conditional transfers with Nerd and Noob', function () {
   it('should create the nerd and the noob', () => {
     let objStore = newSqliteStore()
     nerd = new PluginVirtual({
-      store: objStore,
-      auth: {
-        prefix: 'test.nerd.',
-        host: 'mqatt://test.mosquitto.org',
-        token: token,
-        limit: '1000',
-        balance: '0',
-        account: 'nerd',
-        mockConnection: MockConnection,
-        mockChannels: MockChannels,
-        secret: 'secret'
-      }
+      _store: objStore,
+      host: 'mqatt://test.mosquitto.org',
+      token: token,
+      limit: '1000',
+      balance: '0',
+      account: 'nerd',
+      prefix: 'test.nerd.',
+      mockConnection: MockConnection,
+      mockChannels: MockChannels,
+      secret: 'secret'
     })
     noob = new PluginVirtual({
-      store: {},
-      auth: {
-        host: 'mqatt://test.mosquitto.org',
-        token: token,
-        mockConnection: MockConnection,
-        mockChannels: MockChannels,
-        account: 'noob'
-      }
+      _store: {},
+      host: 'mqatt://test.mosquitto.org',
+      token: token,
+      mockConnection: MockConnection,
+      mockChannels: MockChannels,
+      account: 'noob'
     })
     assert.isObject(noob)
     assert.isObject(nerd)

--- a/test/noobAndNerdSpec.js
+++ b/test/noobAndNerdSpec.js
@@ -1,13 +1,15 @@
 'use strict'
 
+const mockRequire = require('mock-require')
+const mock = require('./helpers/mockConnection')
+const MockConnection = mock.MockConnection
+const MockChannels = mock.MockChannels
+mockRequire('../src/model/connection', MockConnection)
+
 const PluginVirtual = require('..')
 const assert = require('chai').assert
 const newObjStore = require('./helpers/objStore')
 const log = require('../src/util/log')('test')
-
-const mock = require('./helpers/mockConnection')
-const MockConnection = mock.MockConnection
-const MockChannels = mock.MockChannels
 
 let nerd = null
 let noob = null
@@ -44,7 +46,6 @@ describe('The Noob and the Nerd', function () {
       limit: '1000',
       balance: '0',
       account: 'nerd',
-      mockConnection: MockConnection,
       mockChannels: MockChannels,
       secret: 'secret'
     })
@@ -60,7 +61,6 @@ describe('The Noob and the Nerd', function () {
       _store: {},
       host: 'mqtt://test.mosquitto.org',
       token: token,
-      mockConnection: MockConnection,
       mockChannels: MockChannels,
       account: 'noob'
     })
@@ -210,7 +210,6 @@ describe('The Noob and the Nerd', function () {
         _store: {},
         host: 'mqtt://test.mosquitto.org',
         token: token,
-        mockConnection: MockConnection,
         mockChannels: MockChannels,
         account: 'noob2'
       })
@@ -416,7 +415,6 @@ describe('The Noob and the Nerd', function () {
         balance: '0',
         account: 'nerd',
         prefix: 'test.tmpNerd.',
-        mockConnection: MockConnection,
         mockChannels: MockChannels,
         secret: 'secret'
       })

--- a/test/noobAndNerdSpec.js
+++ b/test/noobAndNerdSpec.js
@@ -24,33 +24,29 @@ describe('The Noob and the Nerd', function () {
   it('should throw if the nerd doesn\'t get a prefix', function () {
     assert.throws(() => {
       return new PluginVirtual({
-        store: store1,
-        auth: {
-          host: 'mqtt://test.mosquitto.org',
-          token: token,
-          limit: '1000',
-          balance: '0',
-          account: 'nerd',
-          secret: 'secret'
-        }
-      })
-    }, 'Expected opts.auth.prefix to be a string, received: undefined')
-  })
-
-  it('should instantiate the nerd', () => {
-    nerd = new PluginVirtual({
-      store: store1,
-      auth: {
-        prefix: 'test.nerd.',
+        _store: store1,
         host: 'mqtt://test.mosquitto.org',
         token: token,
         limit: '1000',
         balance: '0',
         account: 'nerd',
-        mockConnection: MockConnection,
-        mockChannels: MockChannels,
         secret: 'secret'
-      }
+      })
+    }, 'Expected opts.prefix to be a string, received: undefined')
+  })
+
+  it('should instantiate the nerd', () => {
+    nerd = new PluginVirtual({
+      _store: store1,
+      host: 'mqtt://test.mosquitto.org',
+      prefix: 'test.nerd.',
+      token: token,
+      limit: '1000',
+      balance: '0',
+      account: 'nerd',
+      mockConnection: MockConnection,
+      mockChannels: MockChannels,
+      secret: 'secret'
     })
     assert.isObject(nerd)
   })
@@ -61,14 +57,12 @@ describe('The Noob and the Nerd', function () {
 
   it('should instantiate the noob', () => {
     noob = new PluginVirtual({
-      store: {},
-      auth: {
-        host: 'mqtt://test.mosquitto.org',
-        token: token,
-        mockConnection: MockConnection,
-        mockChannels: MockChannels,
-        account: 'noob'
-      }
+      _store: {},
+      host: 'mqtt://test.mosquitto.org',
+      token: token,
+      mockConnection: MockConnection,
+      mockChannels: MockChannels,
+      account: 'noob'
     })
     assert.isObject(noob)
   })
@@ -213,14 +207,12 @@ describe('The Noob and the Nerd', function () {
   it('should create a second noob', (done) => {
     next = next.then(() => {
       noob2 = new PluginVirtual({
-        store: {},
-        auth: {
-          host: 'mqtt://test.mosquitto.org',
-          token: token,
-          mockConnection: MockConnection,
-          mockChannels: MockChannels,
-          account: 'noob2'
-        }
+        _store: {},
+        host: 'mqtt://test.mosquitto.org',
+        token: token,
+        mockConnection: MockConnection,
+        mockChannels: MockChannels,
+        account: 'noob2'
       })
       assert.isObject(noob2)
     }).then(() => {
@@ -417,18 +409,16 @@ describe('The Noob and the Nerd', function () {
   it('should hold same balance when nerd is made with old db', (done) => {
     next = next.then(() => {
       let tmpNerd = new PluginVirtual({
-        store: store1,
-        auth: {
-          prefix: 'test.tmpNerd.',
-          host: 'mqatt://test.mosquitto.org',
-          token: token,
-          limit: '1000',
-          balance: '0',
-          account: 'nerd',
-          mockConnection: MockConnection,
-          mockChannels: MockChannels,
-          secret: 'secret'
-        }
+        _store: store1,
+        host: 'mqatt://test.mosquitto.org',
+        token: token,
+        limit: '1000',
+        balance: '0',
+        account: 'nerd',
+        prefix: 'test.tmpNerd.',
+        mockConnection: MockConnection,
+        mockChannels: MockChannels,
+        secret: 'secret'
       })
       return tmpNerd.getBalance()
     }).then((balance) => {


### PR DESCRIPTION
Addresses issue interledger/rfcs#55 . Instead of separating pluginOptions into auth and other options, the structure is flattened and special fields (such as store) are prefixed with an underscore.
