### PR TITLE
Feat: send settle address

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,3 +45,24 @@ When instantiating the plugin, your `opts` need the correct fields.
   "host": "host of MQTT server"
 }
 ```
+
+## Usage (with Optimistic Plugin)
+
+You can also run `ilp-plugin-virtual` such that it will automatically settle its balance when it reaches its
+`settleIfOver` or `settleIfUnder`. In order to do this, the nerd _and_ the noob require some extra configuration.
+In addition to the fields listed above, the nerd and the noob each need to have either:
+
+```js
+"_optimisticPlugin": new IlpPluginExample({ /* opts here */ })
+```
+
+or
+
+```js
+"_optimisticPlugin": "ilp-plugin-example",
+"_optimisticPluginOpts": {
+  // opts for optimistic plugin constructor here
+}
+```
+
+In either case, `ilp-plugin-example` must be accessible.

--- a/test/mocks/mockOptimisticPlugin.js
+++ b/test/mocks/mockOptimisticPlugin.js
@@ -32,6 +32,10 @@ class MockOptimisticPlugin extends EventEmitter {
     )
     this.emit('outgoing_transfer', transfer)
   }
+
+  getAccount () {
+    return Promise.resolve(this.address)
+  }
 }
 
 module.exports = MockOptimisticPlugin

--- a/test/noobAndNerdSpec.js
+++ b/test/noobAndNerdSpec.js
@@ -146,22 +146,6 @@ describe('The Noob and the Nerd', function () {
     })
   })
 
-  it('should trigger settlement when balance under limit', () => {
-    const p = new Promise((resolve) => {
-      noob.once('settlement', (balance) => {
-        resolve()
-      })
-    })
-
-    noob.send({
-      id: 'secondish',
-      account: 'x',
-      amount: '1000'
-    })
-
-    return p
-  })
-
   it('should add balance when nerd sends money to noob', () => {
     const p = new Promise((resolve) => {
       nerd.once('outgoing_transfer', (transfer, message) => {

--- a/test/settleSpec.js
+++ b/test/settleSpec.js
@@ -39,7 +39,6 @@ describe('Automatic settlement', function () {
     nerd = new PluginVirtual({
       _store: objStore,
       _optimisticPlugin: plugin1,
-      settleAddress: 'example.plugin2',
       host: 'mqatt://test.mosquitto.org',
       token: token,
       initialBalance: '0',
@@ -57,7 +56,6 @@ describe('Automatic settlement', function () {
     noob = new PluginVirtual({
       _store: {},
       _optimisticPlugin: plugin2,
-      settleAddress: 'example.plugin1',
       host: 'mqatt://test.mosquitto.org',
       token: token,
       mockConnection: MockConnection,
@@ -76,7 +74,6 @@ describe('Automatic settlement', function () {
         address: 'example.plugin2',
         prefix: 'example.'
       },
-      settleAddress: 'example.plugin1',
       host: 'mqatt://test.mosquitto.org',
       token: token,
       mockConnection: MockConnection,
@@ -97,7 +94,6 @@ describe('Automatic settlement', function () {
         address: 'example.plugin2',
         prefix: 'example.'
       },
-      settleAddress: 'example.plugin2',
       host: 'mqatt://test.mosquitto.org',
       token: token,
       initialBalance: '0',


### PR DESCRIPTION
Both plugins will attach their settlement address to transfers and to settlement notifications, instead of having the address initially configured. This reduces the amount of configuration needed, while still making it impossible to force one plugin to settle for more than their limit.

Also includes documentation on the optimistic plugin configuration.
