### PR TITLE
Refactor: use RPC

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,14 @@ When instantiating the plugin, your `opts` need the correct fields.
 
 ### opts.auth (Nerd)
 
-```json
+```js
 {
   "account": "can be anything; only used for logging",
-  "token": "channel name in MQTT server",
+  "token": "base64url encoded json containing 'host' and 'channel' for mqtt server",
+  "token": { // token can also be an object which gets encoded to the blob
+    "host": "http://mqtt.example/",
+    "channel": "secret channel name"
+  },
   "initialBalance": "starting balance of the trustline",
   "minBalance": "lowest balance allowed (can be negative)",
   "maxBalance": "highest balance allowed",
@@ -38,7 +42,7 @@ When instantiating the plugin, your `opts` need the correct fields.
 ```json
 {
   "account": "can be anything; only used for logging",
-  "token": "channel name in MQTT server",
+  "token": "base64url encoded json containing 'host' and 'channel' for mqtt server",
   "prefix": "prefix for ilp address",
   "settlePercent": "(default 0.5) in [0,1], proportion of distance between current balance and limit to settle to.",
   "balance": "starting balance of the trustline",

--- a/index.js
+++ b/index.js
@@ -13,8 +13,3 @@ module.exports = function (opts) {
     return new NoobPluginVirtual(opts)
   }
 }
-
-module.exports.canConnectToLedger = function (auth) {
-  // TODO: should this ping the server? no.
-  return !!auth
-}

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "validate-commit-msg": "^2.6.1"
   },
   "dependencies": {
+    "base64url": "^2.0.0",
     "bignumber.js": "^2.3.0",
     "co": "^4.6.0",
     "debug": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "lint": "eslint .",
     "test": "istanbul test -- _mocha",
-    "verbose-test": "DEBUG=ilp-plugin-virtual,ethereum,connection,test,server,ilp-plugin-virtual:err,connection:err,test:err,server:err istanbul test -- _mocha"
+    "verbose-test": "DEBUG=ilp-plugin-virtual,rpc,ethereum,test,server,ilp-plugin-virtual:err,connection:err,test:err,server:err istanbul test -- _mocha"
   },
   "repository": {
     "type": "git",
@@ -44,6 +44,7 @@
   },
   "dependencies": {
     "bignumber.js": "^2.3.0",
+    "co": "^4.6.0",
     "debug": "^2.2.0",
     "five-bells-condition": "^3.2.0",
     "mock-require": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "ghooks": "^1.2.1",
     "istanbul": "^0.4.5",
     "mocha": "^2.5.3",
+    "uuid": "^2.0.2",
     "validate-commit-msg": "^2.6.1"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "lint": "eslint .",
     "test": "istanbul test -- _mocha",
-    "verbose-test": "DEBUG=ilp-plugin-virtual,rpc,ethereum,test,server,ilp-plugin-virtual:err,connection:err,test:err,server:err istanbul test -- _mocha"
+    "verbose-test": "DEBUG=* istanbul test -- _mocha"
   },
   "repository": {
     "type": "git",

--- a/src/model/balance.js
+++ b/src/model/balance.js
@@ -81,7 +81,7 @@ class Balance extends EventEmitter {
       let inMax = balance.add(amount).lte(this._max)
       let inWarn = balance.add(amount).lte(this._settleIfOver)
       let positive = amount.gte(this._convert('0'))
-      if (!inWarn) {
+      if (!inWarn && positive) {
         this.emit('over', balance)
       }
       return Promise.resolve(inMax && positive)
@@ -94,7 +94,7 @@ class Balance extends EventEmitter {
       let inMin = balance.sub(amount).gte(this._min)
       let inWarn = balance.sub(amount).gte(this._settleIfUnder)
       let positive = amount.gte(this._convert('0'))
-      if (!inWarn) {
+      if (!inWarn && positive) {
         this.emit('under', balance)
       }
       return Promise.resolve(inMin && positive)

--- a/src/model/connection.js
+++ b/src/model/connection.js
@@ -2,6 +2,7 @@
 const EventEmitter = require('events')
 const log = require('../util/log')('connection')
 const mqtt = require('mqtt')
+const base64url = require('base64url')
 
 class Connection extends EventEmitter {
 
@@ -10,8 +11,11 @@ class Connection extends EventEmitter {
 
     this.config = config
     this.name = config.account
-    this.host = config.host
     this.token = config.token
+
+    const tokenObj = JSON.parse(base64url.decode(this.token))
+    this.channel = tokenObj.channel
+    this.host = tokenObj.host
 
     this.client = null
 
@@ -20,8 +24,8 @@ class Connection extends EventEmitter {
       this.isNoob = false
     }
 
-    this.recvChannel = (this.isNoob ? 'noob_' : 'nerd_') + this.token
-    this.sendChannel = (this.isNoob ? 'nerd_' : 'noob_') + this.token
+    this.recvChannel = (this.isNoob ? 'noob_' : 'nerd_') + this.channel
+    this.sendChannel = (this.isNoob ? 'nerd_' : 'noob_') + this.channel
   }
 
   _log (msg) {

--- a/src/model/rpc.js
+++ b/src/model/rpc.js
@@ -51,7 +51,7 @@ class JsonRpc1 extends EventEmitter {
     try {
       response.result = yield this._methods[request.method].apply(this._that, request.params)
     } catch (e) {
-      console.error('relaying error of type:', e.name)
+      this._log('relaying error of type:', e.name)
       response.error = { type: e.name, message: e.message }
     }
 

--- a/src/model/rpc.js
+++ b/src/model/rpc.js
@@ -1,0 +1,107 @@
+const co = require('co')
+const EventEmitter = require('events')
+const uuid = require('uuid4')
+const debug = require('debug')('rpc')
+
+let n = 1
+
+class JsonRpc1 extends EventEmitter {
+  constructor (connection, that) {
+    super()
+    this._connection = connection
+    this._methods = {}
+    this._that = that
+
+    this._id = n
+    ++n
+
+    this._connection.on('receive', (message) => {
+      if (message.method) {
+        co.wrap(this._handleRequest).call(this, message)
+      } else {
+        co.wrap(this._handleResponse).call(this, message)
+      }
+    })
+  }
+
+  _log () {
+    debug(this._id, ...arguments)
+  }
+
+  addMethod (name, func) {
+    this._methods[name] = func
+  }
+
+  // handle takes an incoming message and returns a result
+  * _handleRequest (request) {
+    if (typeof request.method !== 'string' ||
+        typeof request.params !== 'object' ||
+        !request.id) {
+      return null
+    }
+
+    this._log('got request with id', request.id, 'for method', request.method, 'with params', request.params)
+
+    let response = {
+      result: null,
+      error: null,
+      id: request.id
+    }
+
+    try {
+      response.result = yield this._methods[request.method].apply(this._that, request.params)
+    } catch (e) {
+      console.error('relaying error of type:', e.name)
+      response.error = { type: e.name, message: e.message }
+    }
+    
+    this._log('sending reponse', response)
+    this._connection.send(response)
+  }
+
+  * _handleResponse (response) {
+    if (response.id === null) {
+      this.emit('notification', response.result, response.error)
+    } else {
+      this._log('got response on id', response.id)
+      this.emit('_' + response.id, response)
+    }
+  }
+
+  call (method, params) {
+    const id = uuid()
+
+    const p = new Promise((resolve, reject) => {
+      this.once('_' + id, (response) => {
+        if (response.error) {
+          let e = new Error()
+          e.name = response.error.type
+          e.message = response.error.message
+
+          reject(e)
+        } else {
+          resolve(response.result) 
+        }
+      })
+    })
+
+    this._log('calling', method, 'with', params, 'and id', id)
+    this._connection.send({
+      method: method,
+      params: params,
+      id: id
+    })
+
+    return p
+  }
+
+  notify (result, error) {
+    this._connection.send({
+      result: result || null,
+      error: error || null,
+      id: null
+    })
+  }
+}
+
+module.exports = JsonRpc1

--- a/src/model/rpc.js
+++ b/src/model/rpc.js
@@ -54,7 +54,7 @@ class JsonRpc1 extends EventEmitter {
       console.error('relaying error of type:', e.name)
       response.error = { type: e.name, message: e.message }
     }
-    
+
     this._log('sending reponse', response)
     this._connection.send(response)
   }
@@ -80,7 +80,7 @@ class JsonRpc1 extends EventEmitter {
 
           reject(e)
         } else {
-          resolve(response.result) 
+          resolve(response.result)
         }
       })
     })

--- a/src/model/transferlog.js
+++ b/src/model/transferlog.js
@@ -14,7 +14,18 @@ class TransferLog {
   get (transferId) {
     return this._get('t' + transferId).then((json) => {
       if (json) {
-        return Promise.resolve(JSON.parse(json).transfer)
+        const transfer = JSON.parse(json).transfer
+        return Promise.resolve({
+          id: transfer.id,
+          account: transfer.account,
+          ledger: transfer.ledger,
+          amount: transfer.amount,
+          data: transfer.data,
+          noteToSelf: transfer.noteToSelf,
+          executionCondition: transfer.executionCondition,
+          expiresAt: transfer.expiresAt,
+          custom: transfer.custom
+        })
       } else {
         return Promise.resolve(undefined)
       }

--- a/src/model/transferlog.js
+++ b/src/model/transferlog.js
@@ -21,27 +21,27 @@ class TransferLog {
     })
   }
 
-  getDirection (transferId) {
+  isIncoming (transferId) {
     return this._get('t' + transferId).then((json) => {
       if (json) {
-        return Promise.resolve(JSON.parse(json).direction)
+        return Promise.resolve(JSON.parse(json).isIncoming)
       } else {
         return Promise.resolve(undefined)
       }
     })
   }
 
-  store (transfer, direction) {
+  store (transfer, incoming) {
     return (this._put('t' + transfer.id, JSON.stringify({
       transfer: transfer,
-      direction: direction
+      isIncoming: incoming
     })))
   }
   storeOutgoing (transfer) {
-    return this.store(transfer, this.outgoing)
+    return this.store(transfer, false)
   }
   storeIncoming (transfer) {
-    return this.store(transfer, this.incoming)
+    return this.store(transfer, true)
   }
 
   exists (transferId) {

--- a/src/model/transferlog.js
+++ b/src/model/transferlog.js
@@ -7,8 +7,8 @@ class TransferLog {
     this._get = store.get
     this._put = store.put
     this._del = store.del
-    this.incoming = 'i'
-    this.outgoing = 'o'
+    this.incoming = 'incoming'
+    this.outgoing = 'outgoing'
   }
 
   get (transferId) {

--- a/src/model/transferlog.js
+++ b/src/model/transferlog.js
@@ -76,7 +76,7 @@ class TransferLog {
     })
   }
 
-  fulfill (transferId, fulfillment) {
+  finalize (transferId, fulfillment) {
     // TODO: more efficient way of doing this
     return this._get('t' + transferId).then((json) => {
       const obj = Object.assign(JSON.parse(json), {fulfillment: fulfillment})
@@ -86,7 +86,7 @@ class TransferLog {
     })
   }
 
-  isFulfilled (transferId) {
+  isFinal (transferId) {
     return this._get('f' + transferId).then((data) => {
       return Promise.resolve(data !== undefined)
     })

--- a/src/plugin/nerd_plugin.js
+++ b/src/plugin/nerd_plugin.js
@@ -16,6 +16,7 @@ const JsonRpc1 = require('../model/rpc')
 const TransferLog = require('../model/transferlog').TransferLog
 const log = require('../util/log')('ilp-plugin-virtual')
 const uuid = require('uuid4')
+const base64url = require('base64url')
 
 const cc = require('five-bells-condition')
 
@@ -70,9 +71,16 @@ class NerdPluginVirtual extends EventEmitter {
         typeof opts.prefix)
     }
 
+    let connectionOpts = opts
+    if (typeof opts.token === 'object') {
+      const tokenBlob = base64url(JSON.stringify(opts.token))
+      this._log('token object encoded as: ' + tokenBlob)
+      connectionOpts.token = tokenBlob
+    }
+
     this.connected = false
 
-    this.connection = new Connection(opts)
+    this.connection = new Connection(connectionOpts)
     this.rpc = new JsonRpc1(this.connection, this)
 
     this.settler = opts._optimisticPlugin

--- a/src/plugin/nerd_plugin.js
+++ b/src/plugin/nerd_plugin.js
@@ -25,12 +25,9 @@ const transferEqual = (l, r) => {
     return (l.account === r.account &&
       l.amount - 0 === r.amount - 0 &&
       l.ledger === r.ledger &&
-      (l.executionCondition === r.executionCondition ||
-        l.executionCondition.toString() === r.executionCondition.toString()) &&
-      (l.noteToSelf === r.noteToSelf ||
-        l.noteToSelf.toString() === r.noteToSelf.toString()) &&
-      (l.data === r.data ||
-        l.data.toString() === r.data.toString()) &&
+      l.executionCondition === r.executionCondition &&
+      l.noteToSelf === r.noteToSelf &&
+      l.data === r.data &&
       l.expiresAt === r.expiresAt)
   } catch (e) {
     return false
@@ -73,12 +70,12 @@ class NerdPluginVirtual extends EventEmitter {
     this.store = opts._store
     this.timers = {}
 
-    this.info = opts.info || {
+    this.info = Object.assign({}, (opts.info || {
       precision: 15,
       scale: 15,
       currencyCode: '???',
       currencySymbol: '?'
-    }
+    }), {connectors: [{ connector: opts.connector}]})
 
     this.transferLog = new TransferLog(opts._store)
 

--- a/src/plugin/nerd_plugin.js
+++ b/src/plugin/nerd_plugin.js
@@ -124,7 +124,7 @@ class NerdPluginVirtual extends EventEmitter {
         if (transfer.account !== this.settleAddress) return
         this._log('received a settlement for ' + transfer.amount)
         this.balance.add(transfer.amount).then(() => {
-          return this.balance.get()
+          return this.rpc.call('settled', [])
         })
       })
     }

--- a/src/plugin/noob_plugin.js
+++ b/src/plugin/noob_plugin.js
@@ -30,13 +30,6 @@ class NoobPluginVirtual extends EventEmitter {
 
     this.connected = false
 
-    // create error handling functions
-    let that = this
-    this._handle = (err) => {
-      that.emit('exception', err)
-      throw err
-    }
-
     // establish connections
     this.connection = new Connection(opts)
     this.rpc = new JsonRpc1(this.connection, this)

--- a/src/plugin/noob_plugin.js
+++ b/src/plugin/noob_plugin.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const EventEmitter = require('events')
-const co = require('co')
 
 const Connection = require('../model/connection')
 const JsonRpc1 = require('../model/rpc')
@@ -45,8 +44,8 @@ class NoobPluginVirtual extends EventEmitter {
     // set up the settler
     this.settler = opts._optimisticPlugin
     if (typeof opts._optimisticPlugin === 'string') {
-      const plugin = require(opts._optimisticPlugin)
-      this.settler = new plugin(opts._optimisticPluginOpts)
+      const Plugin = require(opts._optimisticPlugin)
+      this.settler = new Plugin(opts._optimisticPluginOpts)
     }
     this.settleAddress = opts.settleAddress
     this.settlePercent = opts.settlePercent || '0.5'
@@ -70,7 +69,7 @@ class NoobPluginVirtual extends EventEmitter {
         amount: this._getSettleAmount(balance, max),
         id: uuid()
       })
-      
+
       return Promise.resolve(null)
     })
 
@@ -178,7 +177,6 @@ class NoobPluginVirtual extends EventEmitter {
     }).then((account) => {
       return this.rpc.call('send', [outgoingTransfer, account])
     }).then(() => {
-
       if (outgoingTransfer.executionCondition) {
         this.emit('outgoing_prepare', outgoingTransfer)
       } else {

--- a/src/plugin/noob_plugin.js
+++ b/src/plugin/noob_plugin.js
@@ -177,7 +177,9 @@ class NoobPluginVirtual extends EventEmitter {
       }
     }).then((account) => {
       return this.rpc.call('send', [outgoingTransfer, account])
-    }).then(() => {
+    }).then((res) => {
+      if (!res) return Promise.resolve(null)
+
       if (outgoingTransfer.executionCondition) {
         this.emit('outgoing_prepare', outgoingTransfer)
       } else {
@@ -206,6 +208,8 @@ class NoobPluginVirtual extends EventEmitter {
     this._log('fulfilling condition of ' + transferId)
     return this.rpc.call('fulfillCondition', [transferId, fulfillment])
       .then((res) => {
+        if (!res) return Promise.resolve(null)
+
         this.emit(res.direction + '_fulfill', res.transfer, fulfillment)
       })
   }
@@ -224,7 +228,9 @@ class NoobPluginVirtual extends EventEmitter {
     this._log('sending out a manual reject on tid: ' + transferId)
     return this.rpc.call('rejectIncomingTransfer', [transferId])
       .then((transfer) => {
-        this.emit('incoming_reject', transfer)
+        if (transfer) {
+          this.emit('incoming_reject', transfer)
+        }
       })
   }
 

--- a/src/plugin/noob_plugin.js
+++ b/src/plugin/noob_plugin.js
@@ -1,8 +1,10 @@
 'use strict'
 
 const EventEmitter = require('events')
+const co = require('co')
 
 const Connection = require('../model/connection')
+const JsonRpc1 = require('../model/rpc')
 const log = require('../util/log')('ilp-plugin-virtual')
 const uuid = require('uuid4')
 
@@ -22,12 +24,6 @@ class NoobPluginVirtual extends EventEmitter {
   constructor (opts) {
     super()
 
-    let that = this
-    this._handle = (err) => {
-      that.emit('exception', err)
-      throw err
-    }
-
     this.id = opts.id // not used but required for compatability with five
                       // bells connector.
     this._account = opts.account
@@ -35,11 +31,18 @@ class NoobPluginVirtual extends EventEmitter {
 
     this.connected = false
 
-    this.connection = new Connection(opts)
-    this.connection.on('receive', (obj) => {
-      this._receive(obj).catch(this._handle)
-    })
+    // create error handling functions
+    let that = this
+    this._handle = (err) => {
+      that.emit('exception', err)
+      throw err
+    }
 
+    // establish connections
+    this.connection = new Connection(opts)
+    this.rpc = new JsonRpc1(this.connection, this)
+
+    // set up the settler
     this.settler = opts._optimisticPlugin
     if (typeof opts._optimisticPlugin === 'string') {
       const plugin = require(opts._optimisticPlugin)
@@ -48,33 +51,68 @@ class NoobPluginVirtual extends EventEmitter {
     this.settleAddress = opts.settleAddress
     this.settlePercent = opts.settlePercent || '0.5'
 
-    this._expects = {}
-    this._seen = {}
-    this._fulfilled = {}
-
+    // register callbacks for the settler
     if (this.settler) {
-      this.on('_settlement', (obj) => {
-        this.settleAddress = obj.settleAddress || this.settleAddress
-        if (!this.settleAddress) return
-
-        this.settler.send({
-          account: this.settleAddress,
-          amount: this._getSettleAmount(obj.balance, obj.max),
-          id: uuid()
-        })
-      })
-
       this.settler.on('incoming_transfer', (transfer) => {
         if (transfer.account !== this.settleAddress) return
-        this._confirmSettle(transfer)
+        this._log('got incoming transfer for ' + transfer.amount)
+        this.rpc.call('settled', [transfer])
       })
     }
-  }
 
-  _confirmSettle (transfer) {
-    this.connection.send({
-      type: 'settled',
-      transfer: transfer
+    // add handlers to rpc
+    this.rpc.addMethod('settle', (address, balance, max) => {
+      this.settleAddress = address || this.settleAddress
+      if (!this.settleAddress) return
+
+      this.settler.send({
+        account: this.settleAddress,
+        amount: this._getSettleAmount(balance, max),
+        id: uuid()
+      })
+      
+      return Promise.resolve(null)
+    })
+
+    this.rpc.addMethod('send', (transfer, settleAddress) => {
+      if (settleAddress) {
+        this.settleAddress = settleAddress
+      }
+
+      if (transfer.executionCondition) {
+        this.emit('incoming_prepare', transfer)
+      } else {
+        this.emit('incoming_transfer', transfer)
+      }
+
+      return Promise.resolve(true)
+    })
+
+    this.rpc.addMethod('cancel', (transfer, message, direction) => {
+      this.emit(direction + '_cancel', transfer, message)
+      return Promise.resolve(true)
+    })
+
+    this.rpc.addMethod('fulfill', (transfer, direction) => {
+      this.emit(direction + '_fulfill', transfer)
+      return Promise.resolve(true)
+    })
+
+    this.rpc.addMethod('rejectIncomingTransfer', (transfer) => {
+      this.emit('outgoing_reject', transfer)
+      return Promise.resolve(true)
+    })
+
+    this.rpc.addMethod('replyToTransfer', (transfer, message) => {
+      this.emit('reply', transfer, message)
+      return Promise.resolve(true)
+    })
+
+    this.rpc.on('notification', (obj) => {
+      this._log('got notification of type ' + obj.type)
+      switch (obj.type) {
+        case 'balance': this.emit('balance', obj.balance)
+      }
     })
   }
 
@@ -93,169 +131,9 @@ class NoobPluginVirtual extends EventEmitter {
     log.log(this._account + ': ' + msg)
   }
 
-  // These functions prevent messages from being
-  // processed more than once
-  _expectResponse (tid) {
-    this._expects[tid] = true
-  }
-  _expectedResponse (tid) {
-    return !!(this._expects[tid])
-  }
-  _receiveResponse (tid) {
-    this._expects[tid] = false
-  }
-  _seeTransfer (tid) {
-    this._seen[tid] = true
-  }
-  _seenTransfer (tid) {
-    return !!(this._seen[tid])
-  }
-  _fulfilledTransfer (tid) {
-    return !!(this._fulfilled[tid])
-  }
-  _fulfillTransfer (tid) {
-    this._fulfilled[tid] = true
-  }
-
-  // callback for incoming messages
-  _receive (obj) {
-    if (obj.type === 'transfer' && !this._seenTransfer(obj.transfer.id)) {
-      this._seeTransfer(obj.transfer.id)
-      this._log('received a Transfer with tid: ' + obj.transfer.id)
-
-      if (obj.settleAddress) {
-        this.settleAddress = obj.settleAddress
-      }
-
-      if (obj.transfer.executionCondition) {
-        this.emit('incoming_prepare', obj.transfer)
-      } else {
-        this.emit('incoming_transfer', obj.transfer)
-      }
-
-      return this.connection.send({
-        type: 'acknowledge',
-        transfer: obj.transfer,
-        message: 'transfer accepted'
-      })
-    } else if (obj.type === 'acknowledge' &&
-    this._expectedResponse(obj.transfer.id)) {
-      this._receiveResponse(obj.transfer.id)
-      this._log('received an ACK on tid: ' + obj.transfer.id)
-
-      this.emit('_accepted', obj.transfer)
-      if (obj.transfer.executionCondition) {
-        this.emit('outgoing_prepare', obj.transfer)
-      } else {
-        this._log('GOT AN OUTGOING TRANSFER ACCEPTED')
-        this.emit('outgoing_transfer', obj.transfer)
-      }
-
-      return Promise.resolve(null)
-    } else if (obj.type === 'fulfill_execution_condition' &&
-    !this._fulfilledTransfer(obj.transfer.id)) {
-      this._fulfillTransfer(obj.transfer.id)
-
-      this.emit(
-        obj.toNerd ? 'outgoing_fulfill' : 'incoming_fulfill',
-        obj.transfer,
-        new Buffer(obj.fulfillment)
-      )
-
-      return Promise.resolve(null)
-    } else if (obj.type === 'reject' &&
-    !this._fulfilledTransfer(obj.transfer.id)) {
-      this._log('received a reject on tid: ' + obj.transfer.id)
-
-      this.emit('_rejected', obj.transfer)
-      this.emit(
-        obj.toNerd ? 'outgoing_cancel' : 'incoming_cancel',
-        obj.transfer,
-        new Buffer(obj.message)
-      )
-
-      return Promise.resolve(null)
-    } else if (obj.type === 'reply') {
-      this._log('received a reply on tid: ' + obj.transfer.id)
-
-      this.emit('reply', obj.transfer, new Buffer(obj.message))
-
-      return Promise.resolve(null)
-    } else if (obj.type === 'balance') {
-      this._log('received balance: ' + obj.balance)
-
-      this.emit('balance', obj.balance)
-
-      return Promise.resolve(null)
-    } else if (obj.type === 'info') {
-      this._log('received info.')
-
-      this.emit('_info', obj.info)
-
-      return Promise.resolve(null)
-    } else if (obj.type === 'settlement') {
-      this._log('received settlement notification.')
-
-      // internal settlement code requires more values
-      this.emit('_settlement', obj)
-      this.emit('settlement', obj.balance)
-
-      return Promise.resolve(null)
-    } else if (obj.type === 'prefix') {
-      this._log('received prefix.')
-
-      this.emit('_prefix', obj.prefix)
-
-      return Promise.resolve(null)
-    } else if (obj.type === 'manual_reject') {
-      this._log('received manual reject on: ' + obj.transfer.id)
-
-      this.emit('outgoing_reject', obj.transfer, obj.message)
-
-      return Promise.resolve(null)
-    } else if (obj.type === 'manual_reject_failure') {
-      this._log('manual rejection failed on: ' + obj.id)
-
-      this.emit('_manual_reject_failure', obj.id, obj.message)
-
-      return Promise.resolve(null)
-    } else if (obj.type === 'manual_reject_success') {
-      this._log('manual reject success on: ' + obj.transfer.id)
-
-      this.emit('incoming_reject', obj.transfer, obj.message)
-      this.emit('_manual_reject_success', obj.transfer.id)
-
-      return Promise.resolve(null)
-    } else if (obj.type === 'get_fulfillment') {
-      this._log('received fulfillment for tid: ' + obj.transferId)
-
-      this.emit('_get_fulfillment', obj)
-
-      return Promise.resolve(null)
-    } else if (obj.type === 'get_connectors') {
-      this._log('received connectors')
-
-      this.emit('_get_connectors', obj)
-
-      return Promise.resolve(null)
-    } else {
-      this._handle(new Error('Invalid message received'))
-      return Promise.resolve(null)
-    }
-  }
-
   getPrefix () {
-    if (this._prefix) return Promise.resolve(this._prefix)
-    this._log('sending prefix query...')
-    return new Promise((resolve) => {
-      this.on('_prefix', (prefix) => {
-        this._prefix = prefix
-        resolve(prefix)
-      })
-      this.connection.send({
-        type: 'prefix'
-      })
-    })
+    this._log('requesting prefix')
+    return this.rpc.call('getPrefix', [])
   }
 
   connect () {
@@ -286,138 +164,69 @@ class NoobPluginVirtual extends EventEmitter {
   }
 
   getConnectors () {
-    this.connection.send({
-      type: 'get_connectors'
-    })
-    return new Promise((resolve) => {
-      this.once('_get_connectors', (obj) => {
-        resolve(obj.connectors)
-      })
-    })
+    this._log('requesting connectors')
+    return this.rpc.call('getConnectors', [])
   }
 
   send (outgoingTransfer) {
     this._log('sending out a Transfer with tid: ' + outgoingTransfer.id)
-    this._expectResponse(outgoingTransfer.id)
-    return new Promise((resolve, reject) => {
-      let resolved = false
+    return this.getPrefix().then((prefix) => {
+      outgoingTransfer.ledger = prefix
+      if (this.settler) {
+        return this.settler.getAccount()
+      }
+    }).then((account) => {
+      return this.rpc.call('send', [outgoingTransfer, account])
+    }).then(() => {
 
-      this.on('_accepted', (transfer) => {
-        if (!resolved && transfer.id === outgoingTransfer.id) {
-          resolved = true
-          resolve(null)
-        }
-      })
+      if (outgoingTransfer.executionCondition) {
+        this.emit('outgoing_prepare', outgoingTransfer)
+      } else {
+        this.emit('outgoing_transfer', outgoingTransfer)
+      }
 
-      this.on('_rejected', (transfer) => {
-        if (!resolved && transfer.id === outgoingTransfer.id) {
-          resolved = true
-          reject(new Error('transfer was invalid'))
-        }
-      })
-
-      this.getPrefix().then((prefix) => {
-        outgoingTransfer.ledger = prefix
-        if (this.settler) {
-          return this.settler.getAccount()
-        }
-      }).then((account) => {
-        this.connection.send({
-          type: 'transfer',
-          transfer: outgoingTransfer,
-          settleAddress: account
-        }).catch(this._handle)
-      }).catch(this._handle)
+      return Promise.resolve(null)
     })
   }
 
   getBalance () {
-    this._log('sending balance query...')
-    this.connection.send({
-      type: 'balance'
-    })
-    return new Promise((resolve) => {
-      this.once('balance', (balance) => {
-        resolve(balance)
+    this._log('requesting balance')
+    return this.rpc.call('getBalance', [])
+      .then((balance) => {
+        this.emit('balance', balance)
+        return Promise.resolve(balance)
       })
-    })
   }
 
   getInfo () {
-    this._log('sending getInfo query...')
-    this.connection.send({
-      type: 'info'
-    })
-    return new Promise((resolve) => {
-      this.once('_info', (info) => {
-        resolve(info)
-      })
-    })
+    this._log('requesting info')
+    return this.rpc.call('getInfo', [])
   }
 
   fulfillCondition (transferId, fulfillment) {
-    return this.connection.send({
-      type: 'fulfillment',
-      transferId: transferId,
-      fulfillment: fulfillment
-    })
+    this._log('fulfilling condition of ' + transferId)
+    return this.rpc.call('fulfillCondition', [transferId, fulfillment])
+      .then((res) => {
+        this.emit(res.direction + '_fulfill', res.transfer, fulfillment)
+      })
   }
 
   replyToTransfer (transferId, replyMessage) {
-    return this.connection.send({
-      type: 'reply',
-      transferId: transferId,
-      message: replyMessage
-    })
+    this._log('replying to transfer: ' + transferId)
+    return this.rpc.call('replyToTransfer', [transferId, replyMessage])
   }
 
   getFulfillment (transferId) {
-    this.connection.send({
-      type: 'get_fulfillment',
-      transferId: transferId
-    })
-    return new Promise((resolve, reject) => {
-      let received = false
-      this.on('_get_fulfillment', (obj) => {
-        if (received || obj.transferId !== transferId) {
-          return
-        }
-        received = true
-
-        if (!obj.fulfillment) {
-          reject(null)
-        } else {
-          resolve(obj.fulfillment)
-        }
-      })
-    })
+    this._log('requesting fulfillment for ' + transferId)
+    return this.rpc.call('getFulfillment', [transferId])
   }
 
   rejectIncomingTransfer (transferId) {
     this._log('sending out a manual reject on tid: ' + transferId)
-    return new Promise((resolve, reject) => {
-      let resolved = false
-
-      this.on('_manual_reject_success', (transfer) => {
-        if (!resolved && transfer.id === transferId) {
-          resolved = true
-          resolve(null)
-        }
+    return this.rpc.call('rejectIncomingTransfer', [transferId])
+      .then((transfer) => {
+        this.emit('incoming_reject', transfer)
       })
-
-      this.on('_manual_reject_failure', (id, message) => {
-        if (!resolved && transferId === id) {
-          resolved = true
-          reject(new Error(message))
-        }
-      })
-
-      this.connection.send({
-        type: 'manual_reject',
-        transferId: transferId,
-        message: 'manually rejected'
-      }).catch(this._handle)
-    })
   }
 
   getAccount () {

--- a/src/util/errors.js
+++ b/src/util/errors.js
@@ -5,13 +5,6 @@ class InvalidFieldsError extends Error {
   }
 }
 
-class UnreachableError extends Error {
-  constructor () {
-    super(...arguments)
-    this.name = 'UnreachableError'
-  }
-}
-
 class TransferNotFoundError extends Error {
   constructor () {
     super(...arguments)
@@ -42,7 +35,6 @@ class NotAcceptedError extends Error {
 
 module.exports = {
   InvalidFieldsError,
-  UnreachableError,
   TransferNotFoundError,
   MissingFulfillmentError,
   RepeatError,

--- a/src/util/errors.js
+++ b/src/util/errors.js
@@ -1,0 +1,50 @@
+class InvalidFieldsError extends Error {
+  constructor () {
+    super(...arguments)
+    this.name = 'InvalidFieldsError'
+  }
+}
+
+class UnreachableError extends Error {
+  constructor () {
+    super(...arguments)
+    this.name = 'UnreachableError'
+  }
+}
+
+class TransferNotFoundError extends Error {
+  constructor () {
+    super(...arguments)
+    this.name = 'TransferNotFoundError'
+  }
+}
+
+class MissingFulfillmentError extends Error {
+  constructor () {
+    super(...arguments)
+    this.name = 'MissingFulfillmentError'
+  }
+}
+
+class RepeatError extends Error {
+  constructor () {
+    super(...arguments)
+    this.name = 'RepeatError'
+  }
+}
+
+class NotAcceptedError extends Error {
+  constructor () {
+    super(...arguments)
+    this.name = 'NotAcceptedError'
+  }
+}
+
+module.exports = {
+  InvalidFieldsError,
+  UnreachableError,
+  TransferNotFoundError,
+  MissingFulfillmentError,
+  RepeatError,
+  NotAcceptedError
+}

--- a/src/util/errors.js
+++ b/src/util/errors.js
@@ -19,13 +19,6 @@ class MissingFulfillmentError extends Error {
   }
 }
 
-class RepeatError extends Error {
-  constructor () {
-    super(...arguments)
-    this.name = 'RepeatError'
-  }
-}
-
 class NotAcceptedError extends Error {
   constructor () {
     super(...arguments)
@@ -33,10 +26,41 @@ class NotAcceptedError extends Error {
   }
 }
 
+class AlreadyRolledBackError extends Error {
+  constructor () {
+    super(...arguments)
+    this.name = 'AlreadyRolledBackError'
+  }
+}
+
+class AlreadyFulfilledError extends Error {
+  constructor () {
+    super(...arguments)
+    this.name = 'AlreadyFulfilledError'
+  }
+}
+
+class DuplicateIdError extends Error {
+  constructor () {
+    super(...arguments)
+    this.name = 'DuplicateIdError'
+  }
+}
+
+class TransferNotConditionalError extends Error {
+  constructor () {
+    super(...arguments)
+    this.name = 'TransferNotConditionalError'
+  }
+}
+
 module.exports = {
+  AlreadyFulfilledError,
+  AlreadyRolledBackError,
   InvalidFieldsError,
   TransferNotFoundError,
+  TransferNotConditionalError,
+  DuplicateIdError,
   MissingFulfillmentError,
-  RepeatError,
   NotAcceptedError
 }

--- a/test/conditionSpec.js
+++ b/test/conditionSpec.js
@@ -11,9 +11,14 @@ const assert = require('chai').assert
 const newSqliteStore = require('./helpers/sqliteStore')
 const cc = require('five-bells-condition')
 
+const base64url = require('base64url')
+const token = base64url(JSON.stringify({
+  channel: require('crypto').randomBytes(8).toString('hex'),
+  host: 'mqtt://test.mosquitto.org'
+}))
+
 let nerd = null
 let noob = null
-let token = require('crypto').randomBytes(8).toString('hex')
 
 describe('Conditional transfers with Nerd and Noob', function () {
   it('should create the nerd and the noob', () => {
@@ -21,7 +26,6 @@ describe('Conditional transfers with Nerd and Noob', function () {
     let objStore = newSqliteStore()
     nerd = new PluginVirtual({
       _store: objStore,
-      host: 'mqatt://test.mosquitto.org',
       token: token,
       initialBalance: '0',
       maxBalance: '2000',
@@ -36,7 +40,6 @@ describe('Conditional transfers with Nerd and Noob', function () {
     })
     noob = new PluginVirtual({
       _store: {},
-      host: 'mqatt://test.mosquitto.org',
       token: token,
       mockConnection: MockConnection,
       mockChannels: MockChannels,

--- a/test/conditionSpec.js
+++ b/test/conditionSpec.js
@@ -120,7 +120,6 @@ describe('Conditional transfers with Nerd and Noob', function () {
         noob.once('incoming_fulfill', (transfer, fulfillment) => {
           assert(transfer.id === uid)
           assert(transfer.ledger === 'test.nerd.')
-          console.log('this bit')
           resolve()
         })
 

--- a/test/conditionSpec.js
+++ b/test/conditionSpec.js
@@ -292,6 +292,15 @@ describe('Conditional transfers with Nerd and Noob', function () {
     })
   })
 
+  it('should complain on fulfilling a malformed transfer', () => {
+    return new Promise((resolve) => {
+      nerd.fulfillCondition('first', 'garbage').catch((e) => {
+        assert.equal(e.name, 'InvalidFieldsError')
+        resolve()
+      })
+    })
+  })
+
   it('should be able to execute a transfer noob -> nerd', () => {
     const p = new Promise((resolve) => {
       noob.once('outgoing_prepare', (transfer, message) => {
@@ -444,6 +453,22 @@ describe('Conditional transfers with Nerd and Noob', function () {
     })
 
     return p
+  })
+
+  it('should not be able to reject transfer twice as nerd', () => {
+    return nerd.rejectIncomingTransfer('seventh').then(() => {
+      assert(false)
+    }).catch((err) => {
+      assert.equal(err.name, 'RepeatError')
+    })
+  })
+
+  it('should not be able to reject transfer twice as noob', () => {
+    return noob.rejectIncomingTransfer('eighth').then(() => {
+      assert(false)
+    }).catch((err) => {
+      assert.equal(err.name, 'RepeatError')
+    })
   })
 
   it('should not be able to reject nonexistant transfer as noob', () => {

--- a/test/conditionSpec.js
+++ b/test/conditionSpec.js
@@ -321,8 +321,7 @@ describe('Conditional transfers with Nerd and Noob', function () {
 
   it('should complain on fulfilling an transfer twice', () => {
     return new Promise((resolve) => {
-      nerd.fulfillCondition('first', fulfillment).catch((e) => {
-        assert.equal(e.name, 'RepeatError')
+      nerd.fulfillCondition('first', fulfillment).then(() => {
         resolve()
       })
     })

--- a/test/mocks/mockConnection.js
+++ b/test/mocks/mockConnection.js
@@ -9,7 +9,6 @@ class MockConnection extends EventEmitter {
 
     this.config = config
     this.name = config.account
-    this.host = config.host
     this.token = config.token
     this.channels = config.mockChannels
     this.connected = false

--- a/test/noobAndNerdSpec.js
+++ b/test/noobAndNerdSpec.js
@@ -317,23 +317,61 @@ describe('The Noob and the Nerd', function () {
     })
   })
 
-  it('should reject a repeat transfer from the noob', () => {
+  it('should not reject a repeat transfer from the noob', () => {
+    return noob.send({
+      id: 'first',
+      amount: '10',
+      account: 'x'
+    })
+  })
+
+  it('should not reject a repeat transfer from the nerd', () => {
+    return nerd.send({
+      id: 'first',
+      amount: '10',
+      account: 'x'
+    })
+  })
+
+  it('should reject a non-matching repeat transfer from the noob', () => {
     return noob.send({
       id: 'first',
       amount: '100',
       account: 'x'
     }).catch((e) => {
-      assert.equal(e.name, 'RepeatError')
+      assert.equal(e.name, 'DuplicateIdError')
     })
   })
 
-  it('should reject a repeat transfer from the nerd', () => {
+  it('should reject a non-matching repeat transfer from the nerd', () => {
     return nerd.send({
       id: 'first',
       amount: '100',
       account: 'x'
     }).catch((e) => {
-      assert.equal(e.name, 'RepeatError')
+      assert.equal(e.name, 'DuplicateIdError')
+    })
+  })
+
+  it('should reject a non-matching repeat transfer with extra field from the noob', () => {
+    return noob.send({
+      id: 'first',
+      amount: '10',
+      account: 'x',
+      data: new Buffer('')
+    }).catch((e) => {
+      assert.equal(e.name, 'DuplicateIdError')
+    })
+  })
+
+  it('should reject a repeat transfer with extra field from the nerd', () => {
+    return nerd.send({
+      id: 'first',
+      amount: '10',
+      account: 'x',
+      data: new Buffer('')
+    }).catch((e) => {
+      assert.equal(e.name, 'DuplicateIdError')
     })
   })
 

--- a/test/noobAndNerdSpec.js
+++ b/test/noobAndNerdSpec.js
@@ -59,6 +59,26 @@ describe('The Noob and the Nerd', function () {
     assert.isObject(nerd)
   })
 
+  it('should instantiate the nerd with token as object', () => {
+    const tmpNerd = new PluginVirtual({
+      _store: store1,
+      prefix: 'test.nerd.',
+      token: {
+        channel: require('crypto').randomBytes(8).toString('hex'),
+        host: 'mqtt://test.mosquitto.org'
+      },
+      initialBalance: '0',
+      maxBalance: '2000',
+      minBalance: '-1000',
+      settleIfUnder: '-1000',
+      settleIfOver: '2000',
+      account: 'nerd',
+      mockChannels: MockChannels,
+      secret: 'secret'
+    })
+    assert.isObject(tmpNerd)
+  })
+
   it('should instantiate the noob', () => {
     noob = new PluginVirtual({
       _store: {},

--- a/test/noobAndNerdSpec.js
+++ b/test/noobAndNerdSpec.js
@@ -256,21 +256,6 @@ describe('The Noob and the Nerd', function () {
     return p
   })
 
-  it('should reject a false acknowledge from the noob', () => {
-    return noob.connection.send({
-      type: 'acknowledge',
-      transfer: {id: 'fake'},
-      message: 'fake acknowledge'
-    }).then(() => {
-      return new Promise((resolve) => {
-        nerd.once('_falseAcknowledge', (transfer) => {
-          assert(transfer.id === 'fake')
-          resolve()
-        })
-      })
-    })
-  })
-
   it('should reject a repeat transfer from the noob', () => {
     return noob.send({
       id: 'first',
@@ -281,21 +266,6 @@ describe('The Noob and the Nerd', function () {
     })
   })
 
-  it('should emit false reject if a fake transfer is rejected', () => {
-    return noob.connection.send({
-      type: 'reject',
-      transfer: {id: 'notreal'},
-      message: 'fake reject'
-    }).then(() => {
-      return new Promise((resolve) => {
-        nerd.once('_falseReject', (transfer) => {
-          assert(transfer.id === 'notreal')
-          resolve()
-        })
-      })
-    })
-  })
-
   it('should not give an error if a real transfer is rejected', () => {
   // it's harmless to complete a transfer that is already completed if
   // the reject is to a completed transfer.
@@ -303,32 +273,6 @@ describe('The Noob and the Nerd', function () {
       type: 'reject',
       transfer: {id: 'first'},
       message: 'late reject'
-    })
-  })
-
-  it('should give error if the noob sends invalid message type', () => {
-    return noob.connection.send({
-      type: 'garbage'
-    }).then(() => {
-      return new Promise((resolve) => {
-        nerd.once('exception', (err) => {
-          assert(err.message === 'Invalid message received')
-          resolve()
-        })
-      })
-    })
-  })
-
-  it('should give error if the nerd sends invalid message type', () => {
-    return nerd.connection.send({
-      type: 'garbage'
-    }).then(() => {
-      return new Promise((resolve) => {
-        noob.once('exception', (err) => {
-          assert(err.message === 'Invalid message received')
-          resolve()
-        })
-      })
     })
   })
 

--- a/test/noobAndNerdSpec.js
+++ b/test/noobAndNerdSpec.js
@@ -146,6 +146,30 @@ describe('The Noob and the Nerd', function () {
     })
   })
 
+  it('should reject a transfer with an invalid amount (noob)', () => {
+    return noob.send({
+      id: 'invalid_amount',
+      account: 'x',
+      amount: 'garbage'
+    }).then(() => {
+      assert(false)
+    }).catch((e) => {
+      assert.equal(e.name, 'InvalidFieldsError')
+    })
+  })
+
+  it('should reject a transfer with an invalid amount (nerd)', () => {
+    return nerd.send({
+      id: 'invalid_amount_2',
+      account: 'x',
+      amount: 'garbage'
+    }).then(() => {
+      assert(false)
+    }).catch((e) => {
+      assert.equal(e.name, 'InvalidFieldsError')
+    })
+  })
+
   it('should add balance when nerd sends money to noob', () => {
     const p = new Promise((resolve) => {
       nerd.once('outgoing_transfer', (transfer, message) => {
@@ -256,13 +280,39 @@ describe('The Noob and the Nerd', function () {
     return p
   })
 
+  it('should error replying to nonexistant transfer (noob)', () => {
+    return noob.replyToTransfer('nonexistant', 'another message').then(() => {
+      assert(false)
+    }).catch((e) => {
+      assert.equal(e.name, 'TransferNotFoundError')
+    })
+  })
+
+  it('should error replying to nonexistant transfer (nerd)', () => {
+    return nerd.replyToTransfer('nonexistant', 'another message').then(() => {
+      assert(false)
+    }).catch((e) => {
+      assert.equal(e.name, 'TransferNotFoundError')
+    })
+  })
+
   it('should reject a repeat transfer from the noob', () => {
     return noob.send({
       id: 'first',
       amount: '100',
       account: 'x'
     }).catch((e) => {
-      assert(e)
+      assert.equal(e.name, 'RepeatError')
+    })
+  })
+
+  it('should reject a repeat transfer from the nerd', () => {
+    return nerd.send({
+      id: 'first',
+      amount: '100',
+      account: 'x'
+    }).catch((e) => {
+      assert.equal(e.name, 'RepeatError')
     })
   })
 

--- a/test/noobAndNerdSpec.js
+++ b/test/noobAndNerdSpec.js
@@ -10,10 +10,15 @@ const PluginVirtual = require('..')
 const assert = require('chai').assert
 const newObjStore = require('./helpers/objStore')
 
+const base64url = require('base64url')
+const token = base64url(JSON.stringify({
+  channel: require('crypto').randomBytes(8).toString('hex'),
+  host: 'mqtt://test.mosquitto.org'
+}))
+
 let nerd = null
 let noob = null
 let noob2 = null
-let token = require('crypto').randomBytes(8).toString('hex')
 let store1 = newObjStore()
 
 describe('The Noob and the Nerd', function () {
@@ -25,7 +30,6 @@ describe('The Noob and the Nerd', function () {
     assert.throws(() => {
       return new PluginVirtual({
         _store: store1,
-        host: 'mqtt://test.mosquitto.org',
         token: token,
         initialBalance: '0',
         maxBalance: '2000',
@@ -41,7 +45,6 @@ describe('The Noob and the Nerd', function () {
   it('should instantiate the nerd', () => {
     nerd = new PluginVirtual({
       _store: store1,
-      host: 'mqtt://test.mosquitto.org',
       prefix: 'test.nerd.',
       token: token,
       initialBalance: '0',
@@ -59,7 +62,6 @@ describe('The Noob and the Nerd', function () {
   it('should instantiate the noob', () => {
     noob = new PluginVirtual({
       _store: {},
-      host: 'mqtt://test.mosquitto.org',
       token: token,
       mockChannels: MockChannels,
       account: 'noob'
@@ -195,7 +197,6 @@ describe('The Noob and the Nerd', function () {
   it('should create a second noob', () => {
     noob2 = new PluginVirtual({
       _store: {},
-      host: 'mqtt://test.mosquitto.org',
       token: token,
       mockChannels: MockChannels,
       account: 'noob2'
@@ -329,7 +330,6 @@ describe('The Noob and the Nerd', function () {
   it('should hold same balance when nerd is made with old db', () => {
     let tmpNerd = new PluginVirtual({
       _store: store1,
-      host: 'mqatt://test.mosquitto.org',
       token: token,
       initialBalance: '0',
       maxBalance: '2000',

--- a/test/settleSpec.js
+++ b/test/settleSpec.js
@@ -29,9 +29,14 @@ const plugin2 = new OptimisticPlugin({
   prefix: 'example.'
 })
 
+const base64url = require('base64url')
+const token = base64url(JSON.stringify({
+  channel: require('crypto').randomBytes(8).toString('hex'),
+  host: 'mqtt://test.mosquitto.org'
+}))
+
 let nerd = null
 let noob = null
-let token = require('crypto').randomBytes(8).toString('hex')
 
 describe('Automatic settlement', function () {
   it('should create the nerd and the noob', () => {
@@ -39,7 +44,6 @@ describe('Automatic settlement', function () {
     nerd = new PluginVirtual({
       _store: objStore,
       _optimisticPlugin: plugin1,
-      host: 'mqatt://test.mosquitto.org',
       token: token,
       initialBalance: '0',
       minBalance: '-1',
@@ -56,7 +60,6 @@ describe('Automatic settlement', function () {
     noob = new PluginVirtual({
       _store: {},
       _optimisticPlugin: plugin2,
-      host: 'mqatt://test.mosquitto.org',
       token: token,
       mockConnection: MockConnection,
       mockChannels: MockChannels,
@@ -74,7 +77,6 @@ describe('Automatic settlement', function () {
         address: 'example.plugin2',
         prefix: 'example.'
       },
-      host: 'mqatt://test.mosquitto.org',
       token: token,
       mockConnection: MockConnection,
       mockChannels: MockChannels,
@@ -94,7 +96,6 @@ describe('Automatic settlement', function () {
         address: 'example.plugin2',
         prefix: 'example.'
       },
-      host: 'mqatt://test.mosquitto.org',
       token: token,
       initialBalance: '0',
       minBalance: '-1',

--- a/test/settleSpec.js
+++ b/test/settleSpec.js
@@ -153,4 +153,30 @@ describe('Automatic settlement', function () {
 
     return p
   })
+
+  it('should give an error settling without a settler as noob', function () {
+    const id = uuid()
+
+    noob.settler = null
+    noob.send({
+      account: 'ilpdemo.red.alice',
+      amount: '10',
+      id: id
+    }).catch((e) => {
+      assert.equal(e.name, 'NotAcceptedError')
+    })
+  })
+
+  it('should give an error settling without a settler as nerd', function () {
+    const id = uuid()
+
+    nerd.settleAddress = null
+    nerd.send({
+      account: 'ilpdemo.red.alice',
+      amount: '10',
+      id: id
+    }).catch((e) => {
+      assert.equal(e.name, 'NotAcceptedError')
+    })
+  })
 })

--- a/test/storeSpec.js
+++ b/test/storeSpec.js
@@ -72,6 +72,13 @@ describe('TransferLog', function () {
     }).catch(done)
   })
 
+  it('should test if something is complete', (done) => {
+    next = tlog.isComplete('transfer').then((res) => {
+      assert.isFalse(res)
+      done()
+    }).catch(done)
+  })
+
   it('should delete something', (done) => {
     next = next.then(() => {
       return tlog.del('transfer')

--- a/test/storeSpec.js
+++ b/test/storeSpec.js
@@ -149,7 +149,7 @@ describe('Balance', function () {
       initialBalance: 0,
       min: 0,
       max: 1,
-      settleIfOver: {'a':[]},
+      settleIfOver: { 'a': [] },
       settleIfUnder: 0
     })), 'settleIfOver must exist and be a valid number')
   })

--- a/test/storeSpec.js
+++ b/test/storeSpec.js
@@ -92,7 +92,7 @@ describe('TransferLog', function () {
 
   it('should not contain something nonexistant', (done) => {
     next = next.then(() => {
-      return tlog.getDirection('transfer')
+      return tlog.isIncoming('transfer')
     }).then((type) => {
       assert(type === undefined)
       done()


### PR DESCRIPTION
Use [JSON RPC 1.0](http://json-rpc.org/wiki/specification) to communicate between noob and nerd. It reduced the code required, and is _far_ easier to understand than the previous protocol built up over the many iterations of the plugin.

Because RPC also adds the ability to send back errors for remote calls, this pull request includes error types as specified in https://github.com/interledger/rfcs/issues/93.
