### PR TITLE
Fix: treat the store as an instantiated object

### DIFF
--- a/src/model/balance.js
+++ b/src/model/balance.js
@@ -9,8 +9,7 @@ const InvalidFieldsError = errors.InvalidFieldsError
 module.exports = class Balance {
   constructor (opts) {
     this._maximum = new BigNumber(opts.maximum)
-    this._get = opts.store.get
-    this._put = opts.store.put
+    this._store = opts.store
     this._cached = null
 
     // all reserved DB key prefixes are 9 characters
@@ -27,11 +26,11 @@ module.exports = class Balance {
       return this._cached
     }
 
-    const stored = yield this._get(this._key)
+    const stored = yield this._store.get(this._key)
 
     if (!this._isNumber(stored)) {
       debug('stored balance (' + stored + ') is invalid. rewriting as 0.')
-      yield this._put(this._key, '0')
+      yield this._store.put(this._key, '0')
       return new BigNumber('0')
     }
 
@@ -51,13 +50,13 @@ module.exports = class Balance {
     }
 
     this._cached = balance.add(new BigNumber(number))
-    this._put(this._key, this._cached.toString())
+    this._store.put(this._key, this._cached.toString())
   }
 
   * sub (number) {
     this._assertNumber(number)
     this._cached = (yield this._getNumber()).sub(new BigNumber(number))
-    this._put(this._key, this._cached.toString())
+    this._store.put(this._key, this._cached.toString())
   }
 
   * _assertNumber (number) {

--- a/test/helpers/objStore.js
+++ b/test/helpers/objStore.js
@@ -1,16 +1,29 @@
 'use strict'
-function newObjStore (init) {
-  // this simple store just uses an javascript object to store things in memory.
-  var s = init || {}
-  var get = function (k) { return Promise.resolve(s[k]) }
-  var put = function (k, v) { s[k] = v; return Promise.resolve(null) }
-  var del = function (k) { s[k] = undefined; return Promise.resolve(null) }
-  var clone = function () {
-    let newS = JSON.parse(JSON.stringify(s))
-    return newObjStore(newS)
-  }
-  var store = {get: get, put: put, del: del, clone: clone}
+class ObjStore {
 
-  return store
+  constructor (init) {
+    this.s = init || {}
+  }
+  // this simple store just uses an javascript object to store things in memory.
+
+  get (k) {
+    return Promise.resolve(this.s[k])
+  }
+
+  put (k, v) {
+    this.s[k] = v
+    return Promise.resolve(null)
+  }
+
+  del (k) {
+    delete this.s[k]
+    return Promise.resolve(null)
+  }
+
+  clone () {
+    let newS = JSON.parse(JSON.stringify(s))
+    return new ObjStore(newS)
+  }
 }
-module.exports = newObjStore
+
+module.exports = ObjStore

--- a/test/indexSpec.js
+++ b/test/indexSpec.js
@@ -14,14 +14,14 @@ const _ = require('lodash')
 const assert = require('chai').assert
 const expect = require('chai').expect
 
-const newObjStore = require('./helpers/objStore')
+const ObjStore = require('./helpers/objStore')
 const PluginVirtual = require('..')
 const options = {
   currency: 'USD',
   secret: 'seeecret',
   maxBalance: '10',
   peerPublicKey: 'Ivsltficn6wCUiDAoo8gCR0CO5yWb3KBED1a9GrHGwk',
-  _store: newObjStore(),
+  _store: new ObjStore(),
   broker: 'mqtt://example.com',
   // if every test doesn't mock the connection, then the real connection will
   // be cached and the tests will not be able to mock require later

--- a/test/infoSpec.js
+++ b/test/infoSpec.js
@@ -14,7 +14,7 @@ const _ = require('lodash')
 const assert = require('chai').assert
 const expect = require('chai').expect
 
-const newObjStore = require('./helpers/objStore')
+const ObjStore = require('./helpers/objStore')
 const PluginVirtual = require('..')
 
 const info = {
@@ -30,7 +30,7 @@ const options = {
   secret: 'seeecret',
   maxBalance: '10',
   peerPublicKey: 'Ivsltficn6wCUiDAoo8gCR0CO5yWb3KBED1a9GrHGwk',
-  _store: newObjStore(),
+  _store: new ObjStore(),
   broker: 'mqtt://example.com',
   other: {
     'channels': MockChannels,

--- a/test/interface/config.js
+++ b/test/interface/config.js
@@ -9,9 +9,9 @@ mockRequire(
   MockConnection
 )
 
-const newObjStore = require('../helpers/objStore')
-const store1 = newObjStore()
-const store2 = newObjStore()
+const ObjStore = require('../helpers/objStore')
+const store1 = new ObjStore()
+const store2 = new ObjStore()
 
 // This field contains the constructor for a plugin
 exports.plugin = require('../..')

--- a/test/sendSpec.js
+++ b/test/sendSpec.js
@@ -18,7 +18,7 @@ chai.use(require('chai-as-promised'))
 const assert = chai.assert
 const expect = chai.expect
 
-const newObjStore = require('./helpers/objStore')
+const ObjStore = require('./helpers/objStore')
 const PluginVirtual = require('..')
 
 const info = {
@@ -44,8 +44,8 @@ const options = {
 
 describe('Send', () => {
   beforeEach(function * () {
-    this.pluginA = new PluginVirtual(Object.assign({}, options, {_store: newObjStore()}))
-    this.pluginB = new PluginVirtual(Object.assign({}, options, {_store: newObjStore(),
+    this.pluginA = new PluginVirtual(Object.assign({}, options, {_store: new ObjStore()}))
+    this.pluginB = new PluginVirtual(Object.assign({}, options, {_store: new ObjStore(),
       other: {channels: MockChannels, name: 'nerd'}}))
 
     yield this.pluginA.connect()


### PR DESCRIPTION
Assigning `store.get` to `this._get` was causing the `this` parameter in the store to be incorrect. This caused major issues in the connector's store implementation. Now, the store's `this` is respected. The ObjStore class used in the tests has been updated to closer match the connector's pluginStore, in order to prevent future errors of this nature.