### PR TITLE
Fix: validate prefix from options

### DIFF
--- a/src/lib/plugin.js
+++ b/src/lib/plugin.js
@@ -53,6 +53,10 @@ module.exports = class PluginVirtual extends EventEmitter2 {
     this._prefix = 'peer.' + this._token.substring(0, 5) + '.' + this._currency + '.'
     this._account = this._prefix + this._publicKey
 
+    if (opts.prefix && opts.prefix !== this._prefix) {
+      throw new InvalidFieldsError('invalid prefix. got "' + opts.prefix + '", expected "' + this._prefix + '"')
+    }
+
     this._validator = new Validator()
     this._transfers = new TransferLog({
       store: this._store

--- a/test/indexSpec.js
+++ b/test/indexSpec.js
@@ -53,4 +53,9 @@ describe('constructor', () => {
   omitField('peerPublicKey')
   omitField('_store')
   omitField('broker')
+
+  it('should give an error with incorrect prefix passed in', () => {
+    expect(() => new PluginVirtual(Object.assign({}, options, {prefix: 'trash.'})))
+      .to.throw(Error)
+  })
 })

--- a/test/interface/config.js
+++ b/test/interface/config.js
@@ -35,7 +35,7 @@ exports.options = [
       'secret': 'noob_secret',
       'peerPublicKey': 'fkqDV7mm5H29Cd8Q51itbSS6JR3ApdOlS14Po5I1CAc',
       'currency': 'USD',
-      'prefix': 'test.nerd.',
+      'prefix': 'peer.JJkx-.usd.',
       'account': 'nerd',
       'broker': 'ws://broker.hivemq.com:8000',
       'maxBalance': '1000',
@@ -65,7 +65,7 @@ exports.options = [
       'secret': 'nerd_secret',
       'peerPublicKey': 'mOFhdaec9GU5GleNZm3eihSizQd4MxScB8lp8yqEbTw',
       'currency': 'USD',
-      'prefix': 'test.nerd.',
+      'prefix': 'peer.JJkx-.usd.',
       'broker': 'ws://broker.hivemq.com:8000',
       'maxBalance': '1000',
       'other': {


### PR DESCRIPTION
The `prefix` field of `opts` is set by the connector to the prefix in its config. If this prefix doesn't match the one the plugin generates, it could cause major problems in the connector.

This fixes that issue, by making sure the configured prefix is the same as the generated one, and throwing a helpful error otherwise.