### PR TITLE
Refactor: remove lodash

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
     "debug": "^2.2.0",
     "eventemitter2": "^2.2.0",
     "five-bells-condition": "^3.2.0",
-    "lodash": "^4.17.2",
     "mock-require": "^1.3.0",
     "mqtt": "^2.0.1",
     "sodium-prebuilt": "^1.0.22",

--- a/src/model/transferlog.js
+++ b/src/model/transferlog.js
@@ -7,7 +7,6 @@ const NotAcceptedError = errors.NotAcceptedError
 const AlreadyRolledBackError = errors.AlreadyRolledBackError
 const AlreadyFulfilledError = errors.AlreadyFulfilledError
 const MissingFulfillmentError = errors.MissingFulfillmentError
-const _ = require('lodash')
 const debug = require('debug')('ilp-plugin-virtual:store')
 
 module.exports = class TransferLog {
@@ -83,7 +82,7 @@ module.exports = class TransferLog {
   * _storeTransfer (transfer, isIncoming) {
     const stored = yield this._safeGet(transfer.id)
 
-    if (stored && !_.isEqual(transfer, stored)) {
+    if (stored && !deepEqual(transfer, stored)) {
       throw new DuplicateIdError('transfer ' +
         JSON.stringify(transfer) +
         ' matches the id of ' +
@@ -177,4 +176,22 @@ module.exports = class TransferLog {
       this._cacheItems.shift()
     }
   }
+}
+
+const deepEqual = (a, b) => {
+  return deepContains(a, b) && deepContains(b, a)
+}
+
+const deepContains = (a, b) => {
+  if (!a || !b || typeof a !== 'object' || typeof b !== 'object') return false
+  for (let k of Object.keys(a)) {
+    if (a[k] && typeof a[k] === 'object') {
+      if (!deepContains(a[k], b[k])) {
+        return false
+      }
+    } else if (a[k] !== b[k]) {
+      return false
+    }
+  }
+  return true
 }

--- a/test/indexSpec.js
+++ b/test/indexSpec.js
@@ -10,7 +10,6 @@ mockRequire(
   MockConnection
 )
 
-const _ = require('lodash')
 const assert = require('chai').assert
 const expect = require('chai').expect
 
@@ -42,7 +41,7 @@ describe('constructor', () => {
 
   const omitField = (field) => {
     it('should give an error without ' + field, () => {
-      expect(() => new PluginVirtual(_.omit(options, field)))
+      expect(() => new PluginVirtual(Object.assign(options, { [field]: undefined })))
         .to.throw(Error)
     })
   }

--- a/test/infoSpec.js
+++ b/test/infoSpec.js
@@ -10,7 +10,6 @@ mockRequire(
   MockConnection
 )
 
-const _ = require('lodash')
 const assert = require('chai').assert
 const expect = require('chai').expect
 

--- a/test/sendSpec.js
+++ b/test/sendSpec.js
@@ -10,7 +10,6 @@ mockRequire(
   MockConnection
 )
 
-const _ = require('lodash')
 const uuid = require('uuid4')
 
 const chai = require('chai')


### PR DESCRIPTION
https://github.com/interledgerjs/ilp-plugin-virtual/issues/31 . Paring down dependencies. `lodash` was only used in a couple of places. Dependencies are now down to:


```
┌──────────────────────┬──────────────┬────────┐
│ name                 │ children     │ size   │
├──────────────────────┼──────────────┼────────┤
│ sodium-prebuilt      │ 130          │ 15.72M │
├──────────────────────┼──────────────┼────────┤
│ five-bells-condition │ 6            │ 3.72M  │
├──────────────────────┼──────────────┼────────┤
│ mqtt                 │ 92           │ 2.34M  │
├──────────────────────┼──────────────┼────────┤
│ bignumber.js         │ 0            │ 0.24M  │
├──────────────────────┼──────────────┼────────┤
│ base64url            │ 0            │ 0.11M  │
├──────────────────────┼──────────────┼────────┤
│ chai-as-promised     │ 1            │ 0.05M  │
├──────────────────────┼──────────────┼────────┤
│ mock-require         │ 2            │ 0.05M  │
├──────────────────────┼──────────────┼────────┤
│ debug                │ 1            │ 0.04M  │
├──────────────────────┼──────────────┼────────┤
│ eventemitter2        │ 0            │ 0.04M  │
├──────────────────────┼──────────────┼────────┤
│ co                   │ 0            │ 0.02M  │
├──────────────────────┼──────────────┼────────┤
│ uuid4                │ 0            │ 0.00M  │
├──────────────────────┼──────────────┼────────┤
│ 11 modules           │ 205 children │ 21.51M │
└──────────────────────┴──────────────┴────────┘
```