### PR TITLE
Refactor: replace sodium with tweetnacl

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "eventemitter2": "^2.2.0",
     "five-bells-condition": "^3.2.0",
     "nock": "^9.0.2",
-    "sodium-prebuilt": "^1.0.22",
+    "tweetnacl": "^0.14.5",
     "uuid4": "^1.0.0"
   },
   "config": {

--- a/src/util/token.js
+++ b/src/util/token.js
@@ -1,4 +1,4 @@
-const sodium = require('sodium-prebuilt').api
+const tweetnacl = require('tweetnacl')
 const crypto = require('crypto') // sodium doesn't have HMAC
 const base64url = require('base64url')
 
@@ -11,8 +11,8 @@ module.exports = {
     // seed should be a base64url string
     const seedBuffer = base64url.toBuffer(seed)
 
-    return base64url(sodium.crypto_scalarmult_base(
-      sodium.crypto_hash_sha256(seedBuffer)
+    return base64url(tweetnacl.scalarMult.base(
+      crypto.createHash('sha256').update(seedBuffer).digest()
     ))
   },
 
@@ -21,8 +21,8 @@ module.exports = {
     const seedBuffer = base64url.toBuffer(seed)
     const publicKeyBuffer = base64url.toBuffer(publicKey)
 
-    const sharedSecretBuffer = sodium.crypto_scalarmult(
-      sodium.crypto_hash_sha256(seedBuffer),
+    const sharedSecretBuffer = tweetnacl.scalarMult(
+      crypto.createHash('sha256').update(seedBuffer).digest(),
       publicKeyBuffer
     )
 


### PR DESCRIPTION
Now with 100% less sodium.

`sodium-prebuilt` was causing a lot of problems in ILP Kit by not building or downloading files properly. Because speed isn't much of a factor (crypto is only used once in order to generate the trustline prefix), tweetnacl should work fine for us.

This isn't a breaking change. From outside of the module, everything except the dependencies is identical.