### PR TITLE
Feat: use new LPI and validate to/from/ledger fields

### DIFF
--- a/src/util/validator.js
+++ b/src/util/validator.js
@@ -2,6 +2,8 @@
 const BigNumber = require('bignumber.js')
 const cc = require('five-bells-condition')
 const InvalidFieldsError = require('./errors').InvalidFieldsError
+const debug = require('debug')('ilp-plugin-virtual')
+const util = require('util')
 
 module.exports = class Validator {
   constructor (opts) {
@@ -12,18 +14,18 @@ module.exports = class Validator {
 
   validateIncomingTransfer (t) {
     this.validateTransfer(t)
+    if (t.account) return
     this.assertIncoming(t) 
   }
 
   validateOutgoingTransfer (t) {
     this.validateTransfer(t)
+    if (t.account) return
     this.assertOutgoing(t) 
   }
 
   validateTransfer (t) {
     assert(t.id, 'must have an id')
-    assert(t.to, 'must have a destination (.to)')
-    assert(t.from, 'must have a source (.from)')
     assert(t.ledger, 'must have a ledger')
     assert(t.amount, 'must have an amount')
 
@@ -35,27 +37,42 @@ module.exports = class Validator {
     assertCondition(t.executionCondition, 'executionCondition')
     assertString(t.expiresAt, 'expiresAt')
 
+    if (t.account) {
+      util.deprecate(() => {}, 'switch from the "account" field to the "to" and "from" fields!')()
+      assertString(t.account, 'account')
+      return
+    }
+
+    assert(t.to, 'must have a destination (.to)')
+    assert(t.from, 'must have a source (.from)')
     assertPrefix(t.ledger, this._prefix, 'ledger')
   }
 
   validateIncomingMessage (m) {
     this.validateMessage(m)
+    if (m.account) return
     this.assertIncoming(m) 
   }
 
   validateOutgoingMessage (m) {
     this.validateMessage(m)
+    if (m.account) return
     this.assertOutgoing(m)
   }
 
   validateMessage (m) {
-    assert(m.to, 'must have a destination (.to)')
-    assert(m.from, 'must have a source (.from)')
-
     assert(m.ledger, 'must have a ledger')
     assert(m.data, 'must have data')
     assertObject(m.data, 'data')
 
+    if (m.account) {
+      util.deprecate(() => {}, 'switch from the "account" field to the "to" and "from" fields!')()
+      assertString(m.account, 'account')
+      return
+    }
+
+    assert(m.to, 'must have a destination (.to)')
+    assert(m.from, 'must have a source (.from)')
     assertPrefix(m.ledger, this._prefix, 'ledger')
   }
 

--- a/test/conditionSpec.js
+++ b/test/conditionSpec.js
@@ -20,6 +20,7 @@ const info = {
   connectors: [ { id: 'other', name: 'other', connector: 'peer.usd.other' } ]
 }
 
+const peerAddress = 'peer.NavKx.usd.Ivsltficn6wCUiDAoo8gCR0CO5yWb3KBED1a9GrHGwk'
 const options = {
   currency: 'USD',
   secret: 'seeecret',
@@ -42,7 +43,8 @@ describe('Conditional Transfers', () => {
     this.transfer = {
       id: uuid(),
       ledger: this.plugin.getInfo().prefix,
-      account: this.plugin.getAccount(),
+      from: this.plugin.getAccount(),
+      to: peerAddress,
       amount: '5.0',
       data: {
         field: 'some stuff'
@@ -50,6 +52,11 @@ describe('Conditional Transfers', () => {
       executionCondition: this.condition,
       expiresAt: (new Date((new Date()) + 1000)).toISOString()
     }
+
+    this.incomingTransfer = Object.assign({}, this.transfer, {
+      from: peerAddress,
+      to: this.plugin.getAccount()
+    })
 
     yield this.plugin.connect()
   })
@@ -83,7 +90,7 @@ describe('Conditional Transfers', () => {
 
       const fulfilled = new Promise((resolve) => this.plugin.on('incoming_fulfill', resolve))
 
-      yield this.plugin.receive('send_transfer', [this.transfer])
+      yield this.plugin.receive('send_transfer', [this.incomingTransfer])
       yield this.plugin.fulfillCondition(this.transfer.id, this.fulfillment)
       yield fulfilled
 
@@ -129,7 +136,7 @@ describe('Conditional Transfers', () => {
 
       const rejected = new Promise((resolve) => this.plugin.on('incoming_reject', resolve))
 
-      yield this.plugin.receive('send_transfer', [this.transfer])
+      yield this.plugin.receive('send_transfer', [this.incomingTransfer])
       yield this.plugin.rejectIncomingTransfer(this.transfer.id, 'reason')
       yield rejected
 
@@ -159,7 +166,7 @@ describe('Conditional Transfers', () => {
     })
 
     it('should not allow an incoming transfer to be rejected by sender', function * () {
-      yield this.plugin.receive('send_transfer', [this.transfer])
+      yield this.plugin.receive('send_transfer', [this.incomingTransfer])
       yield expect(this.plugin.receive('reject_transfer', [this.transfer.id, 'reason']))
         .to.eventually.be.rejected
     })


### PR DESCRIPTION
Updates `ilp-plugin-virtual` to use https://github.com/interledger/rfcs/pull/151 . Also becomes a lot stricter about having the correct values in the `to`, `from`, and `ledger` fields in transfers and messages.

This is a breaking change due to the change in format and the increase in strictness.