### PR TITLE
Refactor: expose prefix generation function

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,3 +43,17 @@ and parsed body must be passed to the plugin like so:
 ```js
 plugin.receive(method, body)
 ```
+
+# Generate a trustline prefix
+
+If you want to generate a trustline prefix from a secret key, peer's public key, and currency,
+you can access the method through the token class:
+
+```js
+const Token = require('ilp-plugin-virtual/src/util/token')
+const prefix = Token.prefix({
+  secretKey: 'o9Lt0oZFek1ArM_A0HUAq8M8edRuoSeLjX8i10sVUiY',
+  publicKey: 'KRixgcBCBdyQln7IBYiopjuNO78QSFtXgOwP1sbsCSk',
+  currency: 'USD'
+})
+```

--- a/src/lib/plugin.js
+++ b/src/lib/plugin.js
@@ -39,9 +39,6 @@ module.exports = class PluginVirtual extends EventEmitter2 {
     this._peerPublicKey = opts.peerPublicKey
     this._publicKey = Token.publicKey(this._secret)
 
-    // Token uses ECDH to get a secret channel name
-    this._token = Token.token(this._secret, this._peerPublicKey) + '/' + this._currency
-
     this._store = opts._store
     this._maxBalance = opts.maxBalance
     this._balance = new Balance({
@@ -54,7 +51,13 @@ module.exports = class PluginVirtual extends EventEmitter2 {
       this.emit('balance', balance)
     })
 
-    this._prefix = 'peer.' + this._token.substring(0, 5) + '.' + this._currency + '.'
+    // Token uses ECDH to get the ledger prefix from secret and public key
+    this._prefix = Token.prefix({
+      secretKey: this._secret,
+      peerPublicKey: this._peerPublicKey,
+      currency: this._currency
+    })
+
     this._info = Object.assign({}, (opts.info || {}), { prefix: this._prefix })
     this._account = this._prefix + this._publicKey
 

--- a/src/util/token.js
+++ b/src/util/token.js
@@ -4,34 +4,42 @@ const base64url = require('base64url')
 
 const TOKEN_HMAC_INPUT = 'token'
 
+const token = (seed, publicKey) => {
+  // seed and public key should be stored as base64url strings
+  const seedBuffer = base64url.toBuffer(seed)
+  const publicKeyBuffer = base64url.toBuffer(publicKey)
+
+  const sharedSecretBuffer = tweetnacl.scalarMult(
+    crypto.createHash('sha256').update(seedBuffer).digest(),
+    publicKeyBuffer
+  )
+
+  // token is created by feeding the string 'token' into
+  // an HMAC, using the shared secret as the key.
+  return base64url(
+    crypto.createHmac('sha256', sharedSecretBuffer)
+      .update(TOKEN_HMAC_INPUT, 'ascii')
+      .digest()
+  )
+}
+
+const publicKey = (seed) => {
+  // seed should be a base64url string
+  const seedBuffer = base64url.toBuffer(seed)
+
+  return base64url(tweetnacl.scalarMult.base(
+    crypto.createHash('sha256').update(seedBuffer).digest()
+  ))
+}
+
+const prefix = ({ secretKey, peerPublicKey, currency }) => {
+  const tokenPart = token(secretKey, peerPublicKey).substring(0, 5)
+  return ('peer.' + tokenPart + '.' + currency.toLowerCase() + '.')
+}
+
 // use ECDH and HMAC to get the channel's token
 module.exports = {
-
-  publicKey: (seed) => {
-    // seed should be a base64url string
-    const seedBuffer = base64url.toBuffer(seed)
-
-    return base64url(tweetnacl.scalarMult.base(
-      crypto.createHash('sha256').update(seedBuffer).digest()
-    ))
-  },
-
-  token: (seed, publicKey) => {
-    // seed and public key should be stored as base64url strings
-    const seedBuffer = base64url.toBuffer(seed)
-    const publicKeyBuffer = base64url.toBuffer(publicKey)
-
-    const sharedSecretBuffer = tweetnacl.scalarMult(
-      crypto.createHash('sha256').update(seedBuffer).digest(),
-      publicKeyBuffer
-    )
-
-    // token is created by feeding the string 'token' into
-    // an HMAC, using the shared secret as the key.
-    return base64url(
-      crypto.createHmac('sha256', sharedSecretBuffer)
-        .update(TOKEN_HMAC_INPUT, 'ascii')
-        .digest()
-    )
-  }
+  token,
+  publicKey,
+  prefix
 }


### PR DESCRIPTION
A lot of other components want to generate trustline prefixes, so `ilp-plugin-virtual/src/util/token` exposes that now.