### PR TITLE
Fix: get prefix from correct object when expiring

### DIFF
--- a/src/lib/plugin.js
+++ b/src/lib/plugin.js
@@ -280,7 +280,7 @@ module.exports = class PluginVirtual extends EventEmitter2 {
       }
 
       yield that._balance.sub(packaged.transfer.amount)
-      yield that._rpc.call('expire_transfer', this._prefix, [transferId]).catch(() => {})
+      yield that._rpc.call('expire_transfer', that._prefix, [transferId]).catch(() => {})
       yield that.emitAsync((packaged.isIncoming ? 'incoming' : 'outgoing') + '_cancel',
         packaged.transfer)
     }), (expiry - now))

--- a/test/conditionSpec.js
+++ b/test/conditionSpec.js
@@ -121,6 +121,21 @@ describe('Conditional Transfers', () => {
     })
   })
 
+  describe('expireTransfer', () => {
+    it('expires a transfer', function * () {
+      nock('https://example.com')
+        .post('/rpc?method=expire_transfer&prefix=peer.NavKx.usd.', [this.transfer.id])
+        .reply(200, true)
+
+      const cancel = new Promise((resolve) => this.plugin.on('incoming_cancel', resolve))
+
+      yield this.plugin.receive('send_transfer', [this.transfer])
+      yield cancel
+
+      assert.equal((yield this.plugin.getBalance()), '0', 'balance should not change')
+    })
+  })
+
   describe('rejectIncomingTransfer', () => {
     it('rejects an incoming transfer', function * () {
       nock('https://example.com')


### PR DESCRIPTION
because the callback was using `this._prefix` instead of `that._prefix`, it was posting with an undefined prefix.