### PR TITLE
Fix: properly handle RPC request return values

### DIFF
--- a/src/model/rpc.js
+++ b/src/model/rpc.js
@@ -42,6 +42,11 @@ module.exports = class HttpRpc extends EventEmitter {
       })
     ])
 
-    return JSON.parse(result.body)
+    if (result.statusCode !== 200) {
+      throw new Error('Unexpected status code ' + result.statusCode + ', with body "' +
+        res.body + '"')
+    }
+
+    return result.body
   }
 }

--- a/test/sendSpec.js
+++ b/test/sendSpec.js
@@ -41,6 +41,34 @@ describe('Send', () => {
     assert(nock.isDone(), 'nocks should all have been called')
   })
 
+  describe('RPC', () => {
+    it('should throw an error on an error code', function () {
+      nock('https://example.com')
+        .post('/rpc?method=method&prefix=peer.NavKx.usd.', [])
+        .reply(500)
+
+      return expect(this.plugin._rpc.call('method', 'peer.NavKx.usd.', []))
+        .to.eventually.be.rejected
+    })
+
+    it('should accept an object as a response', function () {
+      nock('https://example.com')
+        .post('/rpc?method=method&prefix=peer.NavKx.usd.', [])
+        .reply(200, {
+          a: {
+            b: 'c' 
+          }
+        })
+  
+      return expect(this.plugin._rpc.call('method', 'peer.NavKx.usd.', []))
+        .to.eventually.deep.equal({
+          a: {
+            b: 'c'
+          }
+        })
+    })
+  })
+
   describe('sendMessage', () => {
     beforeEach(function * () {
       this.message = {
@@ -88,14 +116,6 @@ describe('Send', () => {
 
     it('should throw an error on no response', function () {
       this.timeout(3000)
-      return expect(this.plugin.sendMessage(this.message)).to.eventually.be.rejected
-    })
-
-    it('should throw an error on an error code', function () {
-      nock('https://example.com')
-        .post('/rpc?method=send_message&prefix=peer.NavKx.usd.', [this.message])
-        .reply(500)
-
       return expect(this.plugin.sendMessage(this.message)).to.eventually.be.rejected
     })
 


### PR DESCRIPTION
`request` will return an already-parsed object when the `json` flag is set. This error wasn't noticed, because `JSON.parse(true)` doesn't cause an error. This patch allows plugin virtual to receive object responses from the RPC endpoint.