### PR TITLE
Fix: properly set account field

### DIFF
--- a/src/lib/plugin.js
+++ b/src/lib/plugin.js
@@ -121,7 +121,11 @@ module.exports = class PluginVirtual extends EventEmitter2 {
 
   * _handleMessage (message) {
     this._validator.validateIncomingMessage(message)
-    yield this.emitAsync('incoming_message', message)
+
+    // assign legacy account field
+    yield this.emitAsync('incoming_message', Object.assign({},
+      message,
+      { account: this._prefix + this._peerPublicKey }))
     return true
   }
 

--- a/test/sendSpec.js
+++ b/test/sendSpec.js
@@ -108,8 +108,21 @@ describe('Send', () => {
     it('should receive a message', function * () {
       this.message.from = peerAddress
       this.message.to = this.plugin.getAccount()
+      this.message.account = this.plugin.getAccount()
 
-      const incoming = new Promise((resolve) => this.plugin.on('incoming_message', resolve))
+      const incoming = new Promise((resolve, reject) => {
+        this.plugin.on('incoming_message', (message) => {
+          try {
+            assert.deepEqual(message, Object.assign({},
+              this.message,
+              { account: peerAddress }))
+            resolve()
+          } catch (e) {
+            reject(e)
+          }
+        })
+      })
+
       assert.isTrue(yield this.plugin.receive('send_message', [this.message]))
       yield incoming
     })


### PR DESCRIPTION
sets the `account` field on incoming messages. fixes route broadcasting in the ILP kit