### PR TITLE
fix: _getLimit: turn peerMaxBalance into a string

### DIFF
--- a/src/lib/plugin.js
+++ b/src/lib/plugin.js
@@ -314,7 +314,8 @@ module.exports = class PluginVirtual extends EventEmitter2 {
   }
 
   * _getLimit () {
-    const peerMaxBalance = yield this._rpc.call('get_limit', this._prefix, [])
+    // rpc.call turns the balance into a number for some reason, so we turn it back to string
+    const peerMaxBalance = String(yield this._rpc.call('get_limit', this._prefix, []))
     if (isNaN(+peerMaxBalance)) {
       throw new Error('peer returned invalid limt: ' + peerMaxBalance)
     } else if (peerMaxBalance.charAt(0) === '-') {

--- a/src/model/rpc.js
+++ b/src/model/rpc.js
@@ -44,7 +44,7 @@ module.exports = class HttpRpc extends EventEmitter {
 
     if (result.statusCode !== 200) {
       throw new Error('Unexpected status code ' + result.statusCode + ', with body "' +
-        res.body + '"')
+        result.body + '"')
     }
 
     return result.body


### PR DESCRIPTION
`rpc.call ` was turning the `string` `maxBalance` into a `number`, so the `_getLimit` was throwing an exception on `charAt(0)`.