### PR TITLE
Catch event handler errors and run integration tests

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -3,10 +3,15 @@ machine:
     version: 6.2.0
 test:
   override:
+    # Run lint
     - npm run lint
+    # Run tests with coverage
     - npm test
+    # Run integration test suite
+    - if git log -1 --pretty=%B | grep -qF "[skip tests]"; then true; else npm run integration; fi
   post:
-    - bash <(curl -s https://codecov.io/bash)
+    # Upload code coverage data
+    - bash <(curl -s https://codecov.io/bash) || echo "Codecov did not collect coverage reports"
 deployment:
   production:
     branch: master
@@ -14,3 +19,6 @@ deployment:
       # Push NPM package if not yet published
       - mv npmrc-env .npmrc
       - if [ $(npm show ilp-plugin-virtual version) != $(npm ls --depth=-1 2>/dev/null | head -1 | cut -f 1 -d " " | cut -f 2 -d @) ] ; then npm publish ; fi
+general:
+  artifacts:
+    - "coverage/lcov-report"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "scripts": {
     "lint": "eslint .",
-    "test": "istanbul test -- _mocha"
+    "test": "istanbul test -- _mocha",
+    "integration": "integration-loader && integration all"
   },
   "repository": {
     "type": "git",
@@ -37,6 +38,7 @@
     "eslint-config-standard": "^6.0.0",
     "eslint-plugin-promise": "^3.0.0",
     "eslint-plugin-standard": "^2.0.1",
+    "five-bells-integration-test-loader": "^1.2.0",
     "ghooks": "^1.2.1",
     "ilp-plugin-tests": "^1.5.0",
     "istanbul": "^0.4.5",
@@ -62,6 +64,10 @@
     },
     "commitizen": {
       "path": "./node_modules/cz-conventional-changelog"
+    },
+    "five-bells-integration-test-loader": {
+      "module": "five-bells-integration-test",
+      "repo": "interledgerjs/five-bells-integration-test"
     }
   }
 }

--- a/test/conditionSpec.js
+++ b/test/conditionSpec.js
@@ -137,6 +137,30 @@ describe('Conditional Transfers', () => {
 
       yield this.plugin.sendTransfer(this.transfer)
     })
+
+    it('should resolve even if the event notification handler throws an error', function * () {
+      nock('https://example.com')
+        .post('/rpc?method=send_transfer&prefix=peer.NavKx.usd.', [this.transfer])
+        .reply(200, true)
+
+      this.plugin.on('outgoing_prepare', () => {
+        throw new Error('blah')
+      })
+
+      yield this.plugin.sendTransfer(this.transfer)
+    })
+
+    it('should resolve even if the event notification handler rejects', function * () {
+      nock('https://example.com')
+        .post('/rpc?method=send_transfer&prefix=peer.NavKx.usd.', [this.transfer])
+        .reply(200, true)
+
+      this.plugin.on('outgoing_prepare', function * () {
+        throw new Error('blah')
+      })
+
+      yield this.plugin.sendTransfer(this.transfer)
+    })
   })
 
   describe('expireTransfer', () => {


### PR DESCRIPTION
plugin virtual should continue even if an event handler throws or rejects. if it doesn't, the balance may not be updated correctly

possibly related to https://github.com/interledgerjs/ilp-plugin-virtual/issues/50