### PR TITLE
Fix: keep storing conditional transfers even when rpc fails

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "ILP virtual ledger plugin for directly transacting connectors",
   "main": "index.js",
   "scripts": {
-    "lint": "eslint .",
+    "lint": "eslint src test",
     "test": "istanbul test -- _mocha",
     "integration": "integration-loader && integration all"
   },

--- a/src/util/validator.js
+++ b/src/util/validator.js
@@ -5,6 +5,7 @@ const util = require('util')
 
 // Regex matching a string containing 32 base64url-encoded bytes
 const REGEX_32_BYTES_AS_BASE64URL = /^[A-Za-z0-9_-]{43}$/
+const xor = (a, b) => ((a || b) && (!a || !b))
 
 module.exports = class Validator {
   constructor (opts) {
@@ -37,6 +38,12 @@ module.exports = class Validator {
     assertObject(t.custom, 'custom')
     assertConditionOrPreimage(t.executionCondition, 'executionCondition')
     assertString(t.expiresAt, 'expiresAt')
+
+    if (xor(t.executionCondition, t.expiresAt)) {
+      throw new Error('executionCondition (' + t.executionCondition +
+        ') and expiresAt (' + t.expiresAt +
+        ') must both be set if either is set')
+    }
 
     if (t.account) {
       util.deprecate(() => {}, 'switch from the "account" field to the "to" and "from" fields!')()

--- a/test/conditionSpec.js
+++ b/test/conditionSpec.js
@@ -98,6 +98,22 @@ describe('Conditional Transfers', () => {
       assert.equal((yield this.plugin.getBalance()), '5', 'balance should increase by amount')
     })
 
+    it('should fulfill a transfer even if inital RPC failed', function * () {
+      nock('https://example.com')
+        .post('/rpc?method=send_transfer&prefix=peer.NavKx.usd.', [this.transfer])
+        .reply(500)
+
+      const fulfilled = new Promise((resolve) => this.plugin.on('outgoing_fulfill', resolve))
+      const sent = new Promise((resolve) => this.plugin.on('outgoing_prepare', resolve))
+
+      yield this.plugin.sendTransfer(this.transfer)
+      yield sent
+      yield this.plugin.receive('fulfill_condition', [this.transfer.id, this.fulfillment])
+      yield fulfilled
+
+      assert.equal((yield this.plugin.getBalance()), '-5', 'balance should decrease by amount')
+    })
+
     it('doesn\'t fulfill a transfer with invalid fulfillment', function * () {
       nock('https://example.com')
         .post('/rpc?method=send_transfer&prefix=peer.NavKx.usd.', [this.transfer])

--- a/test/infoSpec.js
+++ b/test/infoSpec.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const assert = require('chai').assert
+const nock = require('nock')
 
 const ObjStore = require('./helpers/objStore')
 const PluginVirtual = require('..')
@@ -32,6 +33,28 @@ describe('Info', () => {
   describe('getBalance', () => {
     it('should start at zero', function * () {
       assert.equal((yield this.plugin.getBalance()), '0')
+    })
+  })
+
+  describe('getLimit', () => {
+    it('return the result of the RPC call', function * () {
+      nock('https://example.com')
+        .post('/rpc?method=get_limit&prefix=peer.NavKx.usd.', [])
+        .reply(200, '5')
+
+      // the value is reversed so it makes sense to our side
+      assert.equal((yield this.plugin.getLimit()), '-5')
+    })
+  })
+
+  describe('getPeerBalance', () => {
+    it('return the result of the RPC call', function * () {
+      nock('https://example.com')
+        .post('/rpc?method=get_balance&prefix=peer.NavKx.usd.', [])
+        .reply(200, '5')
+
+      // the value is reversed so it makes sense to our side
+      assert.equal((yield this.plugin.getPeerBalance()), '-5')
     })
   })
 

--- a/test/sendSpec.js
+++ b/test/sendSpec.js
@@ -191,6 +191,17 @@ describe('Send', () => {
       assert.equal((yield this.plugin.getBalance()), '-5', 'balance should decrease by amount')
     })
 
+    it('should roll back a transfer if the RPC call fails', function * () {
+      nock('https://example.com')
+        .post('/rpc?method=send_transfer&prefix=peer.NavKx.usd.', [this.transfer])
+        .reply(500)
+
+      yield this.plugin.sendTransfer(this.transfer)
+        .catch((e) => assert.match(e.message, /Unexpected status code 500/))
+
+      assert.equal((yield this.plugin.getBalance()), '0', 'balance should be rolled back')
+    })
+
     it('should send a transfer with deprecated fields', function * () {
       nock('https://example.com')
         .post('/rpc?method=send_transfer&prefix=peer.NavKx.usd.', [this.transfer])


### PR DESCRIPTION
This will decrease the chances of balance discrepancy if a peer processes a send transfer RPC call, but does not return in time.

The sender will keep the conditional transfer stored even though they think the receiver didn't get it, and if the receiver makes a fulfillCondition RPC call before the timeout, the sender will accept it.

Also adds the `getPeerBalance` function, which makes an RPC call and returns the peer's view of our balance.