### PR TITLE
Fix: remove race conditions in transferlog and balance

### DIFF
--- a/src/lib/plugin.js
+++ b/src/lib/plugin.js
@@ -45,8 +45,8 @@ module.exports = class PluginVirtual extends EventEmitter2 {
     this._store = opts._store
     this._maxBalance = opts.maxBalance
     this._balance = new Balance({
-      store: this._store,
-      maximum: this._maxBalance
+      maximum: this._maxBalance,
+      store: this._store
     })
 
     // give a 'balance' event on balance change
@@ -124,6 +124,9 @@ module.exports = class PluginVirtual extends EventEmitter2 {
   }
 
   * _connect () {
+    // read in from the store and write the balance
+    yield this._balance.connect()
+
     this._connected = true
     this._safeEmit('connect')
   }
@@ -157,8 +160,17 @@ module.exports = class PluginVirtual extends EventEmitter2 {
     // apply the transfer before the other plugin can
     // emit any events about it.
 
-    const repeat = !(yield this._transfers.storeOutgoing(transfer))
-    if (!transfer.executionCondition && !repeat) {
+    // one synchronous check and one asynchronous check allows us to first make
+    // sure that other functions in the event loop can't apply this transfer
+    // (because there's now an entry in the cache that can be checked
+    // synchronously) while also checking the long-term store to see if this
+    // transfer was added in the past.
+    const noRepeat = (this._transfers.cacheOutgoing(transfer) &&
+      (yield this._transfers.notInStore(transfer)))
+
+    if (!transfer.executionCondition && noRepeat) {
+      debug('marking unconditional payment', transfer.id, 'as fulfilled')
+      this._transfers.fulfill(transfer.id)
       yield this._balance.sub(transfer.amount)
     }
 
@@ -171,26 +183,26 @@ module.exports = class PluginVirtual extends EventEmitter2 {
       debug('transfer acknowledged ' + transfer.id)
 
       // end now, so as not to duplicate any effects
-      if (repeat) return
+      if (!noRepeat) return
     } catch (e) {
       // don't roll back, because nothing happened
-      if (repeat) return
+      if (!noRepeat) return
 
       // roll this back, because the other plugin didn't acknowledge
       // the transfer.
       debug(e.name + ' during transfer ' + transfer.id)
       if (!transfer.executionCondition) {
-        yield this._balance.add(transfer.amount)
         // only roll back if the transfer is not conditional.  if the receiver
         // somehow found out about the transfer but failed to respond, they
         // still have a chance to fulfill before the timeout is reached
-        yield this._transfers.drop(transfer.id)
+        this._transfers.drop(transfer.id)
+        yield this._balance.add(transfer.amount)
         throw e
       }
     }
 
     if (transfer.executionCondition) {
-      yield this._setupTransferExpiry(transfer.id, transfer.expiresAt)
+      this._setupTransferExpiry(transfer.id, transfer.expiresAt)
     }
 
     this._safeEmit('outgoing_' +
@@ -199,37 +211,51 @@ module.exports = class PluginVirtual extends EventEmitter2 {
 
   * _handleTransfer (transfer) {
     this._validator.validateIncomingTransfer(transfer)
-    if (!(yield this._transfers.storeIncoming(transfer))) {
+
+    const repeat = !(this._transfers.cacheIncoming(transfer) &&
+      (yield this._transfers.notInStore(transfer)))
+
+    if (repeat) {
       // return if this transfer has already been stored
       return true
     }
 
     // balance is added on incoming transfers, regardless of condition
-    yield this._balance.add(transfer.amount)
-
     this._safeEmit('incoming_' +
       (transfer.executionCondition ? 'prepare' : 'transfer'), transfer)
 
     // set up expiry here too, so both sides can send the expiration message
     if (transfer.executionCondition) {
-      yield this._setupTransferExpiry(transfer.id, transfer.expiresAt)
+      this._setupTransferExpiry(transfer.id, transfer.expiresAt)
+    } else {
+      debug('marking unconditional payment', transfer.id, 'as fulfilled')
+      this._transfers.fulfill(transfer.id)
     }
 
     debug('acknowledging transfer id ', transfer.id)
+    yield this._balance.add(transfer.amount)
     return true
   }
 
   * _fulfillCondition (transferId, fulfillment) {
     this._validator.validateFulfillment(fulfillment)
 
-    yield this._transfers.assertIncoming(transferId)
-    yield this._transfers.assertAllowedChange(transferId, 'executed')
-    const transfer = yield this._transfers.get(transferId)
-
-    yield this._validateFulfillment(fulfillment, transfer.executionCondition)
-    if (yield this._transfers.fulfill(transferId, fulfillment)) {
-      this._safeEmit('incoming_fulfill', transfer, fulfillment)
+    const error = this._transfers.assertAllowedChange(transferId, 'executed')
+    if (error) {
+      yield error
+      // if there wasn't an error thrown but the transfer is not able to be executed,
+      // forward the RPC call to the other end anyways. They might not have gotten it
+      // the first time.
+      yield this._rpc.call('fulfill_condition', this._prefix, [transferId, fulfillment])
+      return
     }
+
+    this._transfers.assertIncoming(transferId)
+    const transfer = this._transfers.get(transferId)
+
+    this._validateFulfillment(fulfillment, transfer.executionCondition)
+    this._transfers.fulfill(transferId, fulfillment)
+    this._safeEmit('incoming_fulfill', transfer, fulfillment)
 
     // let the other person know after we've already fulfilled, because they
     // don't have to edit their database.
@@ -239,66 +265,68 @@ module.exports = class PluginVirtual extends EventEmitter2 {
   * _handleFulfillCondition (transferId, fulfillment) {
     this._validator.validateFulfillment(fulfillment)
 
-    yield this._transfers.assertOutgoing(transferId)
-    yield this._transfers.assertAllowedChange(transferId, 'executed')
-    const transfer = yield this._transfers.get(transferId)
-
-    yield this._validateFulfillment(fulfillment, transfer.executionCondition)
-    if (yield this._transfers.fulfill(transferId, fulfillment)) {
-      yield this._balance.sub(transfer.amount)
-      this._safeEmit('outgoing_fulfill', transfer, fulfillment)
+    const error = this._transfers.assertAllowedChange(transferId, 'executed')
+    if (error) {
+      yield error
+      return true
     }
+
+    this._transfers.assertOutgoing(transferId)
+    const transfer = this._transfers.get(transferId)
+
+    this._validateFulfillment(fulfillment, transfer.executionCondition)
+    this._transfers.fulfill(transferId, fulfillment)
+    this._safeEmit('outgoing_fulfill', transfer, fulfillment)
+    yield this._balance.sub(transfer.amount)
 
     return true
   }
 
   * _rejectIncomingTransfer (transferId, reason) {
-    const transfer = yield this._transfers.get(transferId)
+    const transfer = this._transfers.get(transferId)
     debug('going to reject ' + transferId)
 
-    yield this._transfers.assertIncoming(transferId)
-    if (yield this._transfers.cancel(transferId)) {
-      this._safeEmit('incoming_reject', transfer, reason)
+    const error = this._transfers.assertAllowedChange(transferId, 'cancelled')
+    if (error) {
+      yield error
+      // send another notification to our peer if the error wasn't thrown
+      yield this._rpc.call('reject_incoming_transfer', this._prefix, [transferId, reason])
+      return
     }
-    debug('rejected ' + transferId)
 
+    this._transfers.assertIncoming(transferId)
+
+    debug('rejected ' + transferId)
+    this._transfers.cancel(transferId)
+    this._safeEmit('incoming_reject', transfer, reason)
     yield this._balance.sub(transfer.amount)
     yield this._rpc.call('reject_incoming_transfer', this._prefix, [transferId, reason])
   }
 
   * _handleRejectIncomingTransfer (transferId, reason) {
-    const transfer = yield this._transfers.get(transferId)
+    const transfer = this._transfers.get(transferId)
 
-    yield this._transfers.assertOutgoing(transferId)
-    if (yield this._transfers.cancel(transferId)) {
-      this._safeEmit('outgoing_reject', transfer, reason)
+    const error = this._transfers.assertAllowedChange(transferId, 'cancelled')
+    if (error) {
+      yield error
+      return true
     }
 
-    return true
-  }
-
-  * _handleCancelTransfer (transferId) {
-    const transfer = yield this._transfers.get(transferId)
-    try {
-      if (yield this._transfer.cancel(transferId)) {
-        this._safeEmit('outgoing_cancel', transfer)
-      }
-    } catch (e) {
-      debug(e.message)
-    }
-
+    this._transfers.assertOutgoing(transferId)
+    this._transfers.cancel(transferId)
+    this._safeEmit('outgoing_reject', transfer, reason)
     return true
   }
 
   * _getBalance () {
-    return yield this._balance.get()
+    return Promise.resolve(this._balance.get())
   }
 
   * _getFulfillment (transferId) {
     return yield this._transfers.getFulfillment(transferId)
   }
 
-  * _setupTransferExpiry (transferId, expiresAt) {
+  _setupTransferExpiry (transferId, expiresAt) {
     const expiry = Date.parse(expiresAt)
     const now = new Date()
 
@@ -310,12 +338,11 @@ module.exports = class PluginVirtual extends EventEmitter2 {
   * _expireTransfer (transferId) {
     debug('checking time out on ' + transferId)
 
-    const packaged = yield this._transfers._getPackaged(transferId)
-
     // don't cancel again if it's already cancelled/executed
     try {
-      if (!(yield this._transfers.cancel(transferId))) {
-        debug(transferId + ' is already cancelled')
+      const error = this._transfers.assertAllowedChange(transferId, 'cancelled')
+      if (error) {
+        yield error
         return
       }
     } catch (e) {
@@ -323,20 +350,23 @@ module.exports = class PluginVirtual extends EventEmitter2 {
       return
     }
 
-    if (packaged.isIncoming) {
+    const cached = this._transfers._getCachedTransferWithInfo(transferId)
+    this._transfers.cancel(transferId)
+
+    if (cached.isIncoming) {
       // the balance was only affected when the transfer was incoming.  in the
       // outgoing case, the balance isn't affected until the transfer is
       // fulfilled.
-      yield this._balance.sub(packaged.transfer.amount)
+      yield this._balance.sub(cached.transfer.amount)
     }
 
     yield this._rpc.call('expire_transfer', this._prefix, [transferId]).catch(() => {})
-    this._safeEmit((packaged.isIncoming ? 'incoming' : 'outgoing') + '_cancel',
-      packaged.transfer)
+    this._safeEmit((cached.isIncoming ? 'incoming' : 'outgoing') + '_cancel',
+      cached.transfer)
   }
 
   * _handleExpireTransfer (transferId) {
-    const transfer = yield this._transfers.get(transferId)
+    const transfer = this._transfers.get(transferId)
     const now = new Date()
 
     // only expire the transfer if you agree that it's supposed to be expired
@@ -345,9 +375,14 @@ module.exports = class PluginVirtual extends EventEmitter2 {
         ' (current time is ' + now.toISOString() + ')')
     }
 
-    if (yield this._transfers.cancel(transferId)) {
-      this._safeEmit('outgoing_cancel', transfer)
+    const error = this._transfers.assertAllowedChange(transferId, 'cancelled')
+    if (error) {
+      yield error
+      return true
     }
+
+    this._transfers.cancel(transferId)
+    this._safeEmit('outgoing_cancel', transfer)
 
     return true
   }
@@ -377,7 +412,7 @@ module.exports = class PluginVirtual extends EventEmitter2 {
     return this._stringNegate(peerBalance)
   }
 
-  * _validateFulfillment (fulfillment, condition) {
+  _validateFulfillment (fulfillment, condition) {
     this._validator.validateFulfillment(fulfillment)
     const hash = crypto.createHash('sha256')
     hash.update(fulfillment, 'base64')

--- a/test/helpers/objStore.js
+++ b/test/helpers/objStore.js
@@ -19,11 +19,6 @@ class ObjStore {
     delete this.s[k]
     return Promise.resolve(null)
   }
-
-  clone () {
-    let newS = JSON.parse(JSON.stringify(this.s))
-    return new ObjStore(newS)
-  }
 }
 
 module.exports = ObjStore


### PR DESCRIPTION
Makes all calls to balance and transfer logs synchronous. On the completion of a transfer (once it cannot be modified again), an asynchronous `put` to the store is started in the background. This is accomplished by dumping the plugin store on startup, and putting it all into an in-memory structure for transfers.

The balance works similarly to the transfer log, in that all of its methods are now synchronous and work on a cache. However, each balance adjustment queues a write to the store. These asynchronous operations are chained via promises so they are ensured to happen in order. A later balance update can no longer overwrite an earlier one.