### PR TITLE
Feat: BREAKING authorize RPC requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,12 @@
 
 > ILP virtual ledger plugin for directly transacting connectors
 
+### NOTE:
+
+The current version of `ilp-plugin-virtual` is designed to be used in [ILP
+Kit](https://github.com/interledgerjs/ilp-kit). An HTTP server is required in
+order to pass RPC calls to the plugin, and to perform authorization on RPC calls.
+
 ## Installation
 
 ``` sh

--- a/index.js
+++ b/index.js
@@ -1,4 +1,8 @@
 'use strict'
 
 const PluginVirtual = require('./src/lib/plugin')
+const Token = require('./src/util/token')
+
 module.exports = PluginVirtual
+module.exports.generatePrefix = Token.prefix
+module.exports.generatePublicKey = Token.publicKey

--- a/src/lib/plugin.js
+++ b/src/lib/plugin.js
@@ -55,6 +55,11 @@ module.exports = class PluginVirtual extends EventEmitter2 {
     })
 
     // Token uses ECDH to get the ledger prefix from secret and public key
+    this._authToken = Token.authToken({
+      secretKey: this._secret,
+      peerPublicKey: this._peerPublicKey
+    })
+
     this._prefix = Token.prefix({
       secretKey: this._secret,
       peerPublicKey: this._peerPublicKey,
@@ -84,7 +89,12 @@ module.exports = class PluginVirtual extends EventEmitter2 {
     this._connected = false
 
     // register RPC methods
-    this._rpc = new HttpRpc(opts.rpcUri, this)
+    this._rpc = new HttpRpc({
+      rpcUri: opts.rpcUri,
+      plugin: this,
+      authToken: this._authToken
+    })
+
     this._rpc.addMethod('send_message', this._handleMessage)
     this._rpc.addMethod('send_transfer', this._handleTransfer)
     this._rpc.addMethod('fulfill_condition', this._handleFulfillCondition)
@@ -110,6 +120,7 @@ module.exports = class PluginVirtual extends EventEmitter2 {
     this.getInfo = () => JSON.parse(JSON.stringify(this._info))
     this.isConnected = () => this._connected
     this.getAccount = () => this._account
+    this.isAuthorized = (authToken) => (authToken === this._authToken)
   }
 
   // don't throw errors even if the event handler throws

--- a/src/model/rpc.js
+++ b/src/model/rpc.js
@@ -5,11 +5,12 @@ const request = require('co-request')
 
 // TODO: really call it HTTP RPC?
 module.exports = class HttpRpc extends EventEmitter {
-  constructor (rpcUri, that) {
+  constructor ({ rpcUri, plugin, authToken }) {
     super()
     this._methods = {}
-    this._that = that
+    this._plugin = plugin
     this.rpcUri = rpcUri
+    this.authToken = authToken
 
     this.receive = co.wrap(this._receive).bind(this)
     this.call = co.wrap(this._call).bind(this)
@@ -21,7 +22,7 @@ module.exports = class HttpRpc extends EventEmitter {
 
   * _receive (method, params) {
     // TODO: 4XX when method doesn't exist
-    return yield this._methods[method].apply(this._that, params)
+    return yield this._methods[method].apply(this._plugin, params)
   }
 
   * _call (method, prefix, params) {
@@ -33,6 +34,7 @@ module.exports = class HttpRpc extends EventEmitter {
         method: 'POST',
         uri: uri,
         body: params,
+        auth: { bearer: this.authToken },
         json: true
       }),
       new Promise((resolve, reject) => {

--- a/test/indexSpec.js
+++ b/test/indexSpec.js
@@ -24,6 +24,10 @@ describe('constructor', () => {
     assert.isObject(new PluginVirtual(options))
   })
 
+  it('should export the generatePrefix method from the module', () => {
+    assert.isFunction(PluginVirtual.generatePrefix)
+  })
+
   const omitField = (field) => {
     it('should give an error without ' + field, () => {
       expect(() => new PluginVirtual(Object.assign(options, { [field]: undefined })))

--- a/test/infoSpec.js
+++ b/test/infoSpec.js
@@ -65,6 +65,16 @@ describe('Info', () => {
     })
   })
 
+  describe('isAuthorized', () => {
+    it('should authorize its own auth token', function () {
+      assert.isTrue(this.plugin.isAuthorized(this.plugin._authToken))
+    })
+
+    it('should not authorize any other token', function () {
+      assert.isFalse(this.plugin.isAuthorized('any other token'))
+    })
+  })
+
   describe('disconnect', () => {
     it('should disconnect when connected', function * () {
       assert.isTrue(this.plugin.isConnected(), 'should have connected before')

--- a/test/sendSpec.js
+++ b/test/sendSpec.js
@@ -51,6 +51,19 @@ describe('Send', () => {
         .to.eventually.be.rejected
     })
 
+    it('should send authorization bearer token', function () {
+      nock('https://example.com', {
+        reqheaders: {
+          'Authorization': 'Bearer ' + this.plugin._authToken
+        }
+      })
+        .post('/rpc?method=method&prefix=peer.NavKx.usd.2.', [])
+        .reply(200, { a: 'b' })
+
+      return expect(this.plugin._rpc.call('method', 'peer.NavKx.usd.2.', []))
+        .to.eventually.deep.equal({ a: 'b' })
+    })
+
     it('should accept an object as a response', function () {
       nock('https://example.com')
         .post('/rpc?method=method&prefix=peer.NavKx.usd.2.', [])


### PR DESCRIPTION
Adds an `authorize(token)` method to plugin-virtual, and includes a bearer token in plugin-virtual's RPC calls. The plugin uses a symmetric token (an HMAC of the shared secret) to authenticate RPC requests. Depends on https://github.com/interledgerjs/ilp-kit/pull/291