### PR TITLE
Feat: add asymmetric trustline support

### DIFF
--- a/src/lib/plugin.js
+++ b/src/lib/plugin.js
@@ -293,8 +293,10 @@ module.exports = class PluginVirtual extends EventEmitter2 {
       debug(e.name + ' during transfer ' + transfer.id)
     }
 
-    this._setupTransferExpiry(transfer.id, transfer.expiresAt)
     this._safeEmit('outgoing_prepare', transfer)
+    if (this._stateful) {
+      this._setupTransferExpiry(transfer.id, transfer.expiresAt)
+    }
   }
 
   async _handleTransfer (transfer) {
@@ -321,7 +323,9 @@ module.exports = class PluginVirtual extends EventEmitter2 {
 
     // set up expiry here too, so both sides can send the expiration message
     this._safeEmit('incoming_prepare', transfer)
-    this._setupTransferExpiry(transfer.id, transfer.expiresAt)
+    if (this._stateful) {
+      this._setupTransferExpiry(transfer.id, transfer.expiresAt)
+    }
 
     debug('acknowledging transfer id ', transfer.id)
     return true

--- a/src/model/rpc.js
+++ b/src/model/rpc.js
@@ -4,12 +4,13 @@ const request = require('co-request')
 
 // TODO: really call it HTTP RPC?
 module.exports = class HttpRpc extends EventEmitter {
-  constructor ({ rpcUri, plugin, authToken }) {
+  constructor ({ rpcUris, plugin, authToken, tolerateFailure }) {
     super()
     this._methods = {}
     this._plugin = plugin
-    this.rpcUri = rpcUri
+    this.rpcUris = rpcUris
     this.authToken = authToken
+    this.tolerateFailure = tolerateFailure
   }
 
   addMethod (name, handler) {
@@ -17,14 +18,29 @@ module.exports = class HttpRpc extends EventEmitter {
   }
 
   async receive (method, params) {
-    // TODO: 4XX when method doesn't exist
+    if (!this._methods[method]) {
+      throw new Error('no method "' + method + '" found.')
+    }
+
     return await this._methods[method].apply(this._plugin, params)
   }
 
   async call (method, prefix, params) {
+    const results = await Promise.all(this.rpcUris.map((uri) => {
+      return this._callUri(uri, method, prefix, params)
+        .catch((e) => {
+          if (!this.tolerateFailure) throw e
+        })
+    }))
+
+    // TODO: another way of choosing result?
+    return results[0]
+  }
+
+  async _callUri (rpcUri, method, prefix, params) {
     debug('calling', method, 'with', params)
 
-    const uri = this.rpcUri + '?method=' + method + '&prefix=' + prefix
+    const uri = rpcUri + '?method=' + method + '&prefix=' + prefix
     const result = await Promise.race([
       request({
         method: 'POST',
@@ -43,7 +59,7 @@ module.exports = class HttpRpc extends EventEmitter {
     // 401 is a common error when a peering relationship isn't mutual, so a more
     // helpful error is printed.
     if (result.statusCode === 401) {
-      throw new Error('Unable to call "' + this.rpcUri +
+      throw new Error('Unable to call "' + rpcUri +
         '" (401 Unauthorized). They may not have you as a peer. (error body=' +
         JSON.stringify(result.body) + ')')
     }


### PR DESCRIPTION
By not specifying the store you can make a plugin stateless, so that it relies on its peer for state. In flight payments are still kept in a cache.

Additionally:

- An auth token and prefix can be set manually as an alternative to the diffie-hellman approach.
- Multiple RPC URIs can be specified, to allow several people to listen on an account.
- opts.tolerateFailure can be set to allow RPC requests to fail silently.
- A minimum balance can be specified, allowing the stateful plugin to keep an upper limit for the stateless plugin. The lowest possible balance is tracked so that this limit can never be exceeded.
- The validator is improved for the latest LPI
- Deprecated optimistic transfers have now been removed completely, to simplify logic.
- Deprecated `account` field has been removed, to simplify API.

Major version.