### PR TITLE
feat: allow 204 response code

### DIFF
--- a/src/model/rpc.js
+++ b/src/model/rpc.js
@@ -48,7 +48,7 @@ module.exports = class HttpRpc extends EventEmitter {
         JSON.stringify(result.body) + ')')
     }
 
-    if (result.statusCode !== 200) {
+    if (result.statusCode !== 200 && result.statusCode !== 204) {
       throw new Error('Unexpected status code ' + result.statusCode + ', with body "' +
         JSON.stringify(result.body) + '"')
     }


### PR DESCRIPTION
From my ilp-kit logs:
```sh
[api] 2017-07-04T07:50:09.697Z ilp-routing:routing-tables debug invalidateConnector connectorAccount: peer.Mfqyd.usd.9.8Zq10b79NO7RGHgfrX4lCXPbhVXL3Gt63SVLRH-BvR0
[api] 2017-07-04T07:50:09.699Z ilp-routing:routing-tables debug invalidateConnector connectorAccount: peer.Mfqyd.usd.9.8Zq10b79NO7RGHgfrX4lCXPbhVXL3Gt63SVLRH-BvR0
[api] 2017-07-04T07:50:09.699Z connector:route-broadcaster info detectedDown! account: peer.Mfqyd.usd.9.8Zq10b79NO7RGHgfrX4lCXPbhVXL3Gt63SVLRH-BvR0 lostLedgerLinks: []
[api] 2017-07-04T07:50:09.700Z connector:route-broadcaster warn broadcasting routes to peer.Mfqyd.usd.9.8Zq10b79NO7RGHgfrX4lCXPbhVXL3Gt63SVLRH-BvR0 failed
[api] 2017-07-04T07:50:09.701Z connector:route-broadcaster debug Error: Unexpected status code 204, with body "undefined"
[api]     at HttpRpc.call (/usr/src/app/node_modules/ilp-plugin-virtual/src/model/rpc.js:52:13)
[api]     at process._tickCallback (internal/process/next_tick.js:109:7)
```

I think either koa or nginx is probably setting this response code when the response to a route broadcast has a zero-length body. We could be strict and require a 200 response in that case, but I thought allowing 204 is nicer, especially if we start thinking of the rpc end point as the ilp-kit's API which other applications talk to.