### PR TITLE
docs: report this.rpcUri for debugging

### DIFF
--- a/src/model/rpc.js
+++ b/src/model/rpc.js
@@ -18,11 +18,12 @@ module.exports = class HttpRpc extends EventEmitter {
 
   async receive (method, params) {
     // TODO: 4XX when method doesn't exist
+    debug('incoming', method, 'from', this.rpcUri, 'with', params)
     return await this._methods[method].apply(this._plugin, params)
   }
 
   async call (method, prefix, params) {
-    debug('calling', method, 'with', params)
+    debug('outgoing', method, 'to', this.rpcUri, 'with', params)
 
     const uri = this.rpcUri + '?method=' + method + '&prefix=' + prefix
     const result = await Promise.race([
@@ -49,7 +50,7 @@ module.exports = class HttpRpc extends EventEmitter {
     }
 
     if (result.statusCode !== 200) {
-      throw new Error('Unexpected status code ' + result.statusCode + ', with body "' +
+      throw new Error('Unexpected status code ' + result.statusCode + ' from ' + this.rpcUri + ', with body "' +
         JSON.stringify(result.body) + '"')
     }
 


### PR DESCRIPTION
Looks like this in the logs:
```sh
[api] 2017-07-05T14:56:30.353Z ilp-plugin-virtual:rpc debug outgoing send_request to https://hive.dennisappelt.com/api/peers/rpc with [ { ledger: 'peer.iv7Xl.usd.9.',
[api]     from: 'peer.iv7Xl.usd.9.q4GKIRafX0MnXBOGJESFxmdGHG8o6P6_Bp1ZZL69ck4',
[api]     to: 'peer.iv7Xl.usd.9.0m6XDxXg4mvomAkbUMLdn2a9d1I_1ALNe8xbZFLXHEU',
[api]     custom: { method: 'broadcast_routes', data: [Object] },
[api]     timeout: 30000 } ]
```
so we can immediately see 'hive.dennisappelt.com' and don't have to be guessing anymore which peer corresponds to 'peer.iv7Xl.usd.9.'